### PR TITLE
Fix Spotify playback disconnection issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/ca/tunaro/MainActivity.java
+++ b/app/src/main/java/com/ca/tunaro/MainActivity.java
@@ -16,6 +16,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.spotify.android.appremote.api.ConnectionParams;
 import com.spotify.android.appremote.api.Connector;
 import com.spotify.android.appremote.api.SpotifyAppRemote;
+import com.spotify.protocol.types.Track;
 import com.spotify.sdk.android.auth.AuthorizationClient;
 import com.spotify.sdk.android.auth.AuthorizationRequest;
 import com.spotify.sdk.android.auth.AuthorizationResponse;
@@ -285,7 +286,7 @@ public class MainActivity extends AppCompatActivity {
             //        });
 //    }
 
-    private void connectSpotifyAppRemote() {
+    public void connectSpotifyAppRemote() {
         // Connect to Spotify App Remote here
 
         ConnectionParams connectionParams =
@@ -296,30 +297,32 @@ public class MainActivity extends AppCompatActivity {
 
         SpotifyAppRemote.connect(this, connectionParams,
                 new Connector.ConnectionListener() {
-
                     public void onConnected(SpotifyAppRemote spotifyAppRemote) {
                         mSpotifyAppRemote = spotifyAppRemote;
                         Log.d("MainActivity", "Connected to remote");
+                        // Store this for later use
+                        onSpotifyRemoteConnected();
                     }
 
                     public void onFailure(Throwable throwable) {
-                        Log.e("MyActivity", throwable.getMessage(), throwable);
-
-                        // Something went wrong when attempting to connect
+                        Log.e("MainActivity", "Remote connection failed: " + throwable.getMessage(), throwable);
+                        Toast.makeText(MainActivity.this,
+                                "Failed to connect to Spotify. Please ensure the Spotify app is installed.",
+                                Toast.LENGTH_LONG).show();
                     }
                 });
     }
 
-//    public void start(View v) {
-//        disable(v);
-//
-//        //Subscribe to PlayerState
-//        mSpotifyAppRemote.getPlayerApi()
-//                .subscribeToPlayerState()
-//                .setEventCallback(playerState -> {
-//                    final Track track = playerState.track;
-//                    if (track != null) {
-//                        Log.d("MainActivity", track.name + " by " + track.artist.name);
+    public void start(View v) {
+        disable(v);
+
+        //Subscribe to PlayerState
+        mSpotifyAppRemote.getPlayerApi()
+                .subscribeToPlayerState()
+                .setEventCallback(playerState -> {
+                    final Track track = playerState.track;
+                    if (track != null) {
+                        Log.d("MainActivity", track.name + " by " + track.artist.name);
 //                        TextView trackDisplay = findViewById(R.id.trackDisplay);
 //                        TextView artistDisplay = findViewById(R.id.artistDisplay);
 //                        ImageView songCover = findViewById(R.id.songCover);
@@ -327,9 +330,9 @@ public class MainActivity extends AppCompatActivity {
 //                        artistDisplay.setText(track.artist.name);
 //                        Uri imageURI = Uri.parse(track.imageUri.raw);
 //                        songCover.setImageURI(imageURI);
-//                    }
-//                });
-//    }
+                    }
+                });
+    }
 
     private CompletableFuture<Void> getCurrentUsersProfile_Async() {
         final GetCurrentUsersProfileRequest getCurrentUsersProfileRequest = spotifyApi.getCurrentUsersProfile()
@@ -354,10 +357,19 @@ public class MainActivity extends AppCompatActivity {
                 });
     }
 
+    /**
+     * Disconnect from Spotify remote.
+     * Note: only disconnect from Spotify when the app is actually closing,
+     * not during navigation between activities. This ensures the connection
+     * remains active when playing songs from other screens.
+     */
     @Override
     protected void onStop() {
         super.onStop();
-        SpotifyAppRemote.disconnect(mSpotifyAppRemote);
+        // Only disconnect if the app is actually closing
+        if (isFinishing()) {
+            SpotifyAppRemote.disconnect(mSpotifyAppRemote);
+        }
     }
 
     @Override
@@ -399,6 +411,10 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    private void onSpotifyRemoteConnected() {
+        // Enable UI elements that require Spotify connection
+        Toast.makeText(this, "Connected to Spotify", Toast.LENGTH_SHORT).show();
+    }
 
     private void updateUILoggedIn() {
         // Update your UI elements to reflect logged-in state

--- a/app/src/main/java/com/ca/tunaro/PlayFragment.java
+++ b/app/src/main/java/com/ca/tunaro/PlayFragment.java
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import com.spotify.android.appremote.api.SpotifyAppRemote;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +26,6 @@ public class PlayFragment extends Fragment implements Playlist_RecyclerViewInter
     private Playlist_RecyclerViewAdapter adapter;
     private final ArrayList<PlaylistModel> playlistModels = new ArrayList<>();
     private SwipeRefreshLayout swipeRefreshLayout;
-    private RecyclerView recyclerView;
     private MainActivity mainActivity;
     private boolean isRefreshing = false;
     private DatabaseHelper dbHelper;
@@ -42,7 +43,7 @@ public class PlayFragment extends Fragment implements Playlist_RecyclerViewInter
         view = inflater.inflate(R.layout.fragment_play, container, false);
 
         // Initialize RecyclerView
-        recyclerView = view.findViewById(R.id.mRecyclerView);
+        RecyclerView recyclerView = view.findViewById(R.id.mRecyclerView);
         adapter = new Playlist_RecyclerViewAdapter(getContext(), this, this);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(adapter);
@@ -58,25 +59,26 @@ public class PlayFragment extends Fragment implements Playlist_RecyclerViewInter
         archiveToggleButton = view.findViewById(R.id.archiveToggleButton);
         archiveToggleButton.setOnClickListener(v -> toggleArchivedView());
 
-        SwipeToArchiveCallback.OnSwipeListener archiveListener = new SwipeToArchiveCallback.OnSwipeListener() {
-            @Override
-            public void onArchive(int position) {
-                PlaylistModel playlist = getPlaylistModels().get(position);
-                if (showingArchived) {
-                    dbHelper.unarchivePlaylist(playlist.getId());
-                    Toast.makeText(requireContext(), "Playlist unarchived", Toast.LENGTH_SHORT).show();
-                } else {
-                    dbHelper.archivePlaylist(playlist.getId());
-                    Toast.makeText(requireContext(), "Playlist archived", Toast.LENGTH_SHORT).show();
-                }
-                refreshPlaylists();
-            }
-        };
-
-        SwipeToArchiveCallback swipeHandler = new SwipeToArchiveCallback(adapter, archiveListener, showingArchived);
+        SwipeToArchiveCallback swipeHandler = getSwipeToArchiveCallback();
         new ItemTouchHelper(swipeHandler).attachToRecyclerView(recyclerView);
 
         return view;
+    }
+
+    private @NonNull SwipeToArchiveCallback getSwipeToArchiveCallback() {
+        SwipeToArchiveCallback.OnSwipeListener archiveListener = position -> {
+            PlaylistModel playlist = getPlaylistModels().get(position);
+            if (showingArchived) {
+                dbHelper.unarchivePlaylist(playlist.getId());
+                Toast.makeText(requireContext(), "Playlist unarchived", Toast.LENGTH_SHORT).show();
+            } else {
+                dbHelper.archivePlaylist(playlist.getId());
+                Toast.makeText(requireContext(), "Playlist archived", Toast.LENGTH_SHORT).show();
+            }
+            refreshPlaylists();
+        };
+
+        return new SwipeToArchiveCallback(adapter, archiveListener, showingArchived);
     }
 
     @Override
@@ -168,7 +170,8 @@ public class PlayFragment extends Fragment implements Playlist_RecyclerViewInter
         SelectedPlaylistHolder.getInstance().setSelectedPlaylist(
                 clickedPlaylist,
                 mainActivity.getSpotifyApi(),
-                mainActivity.getSpotifyAppRemote()
+                mainActivity.getSpotifyAppRemote(),
+                mainActivity
         );
 
         // Start the PlaylistView activity
@@ -223,13 +226,23 @@ public class PlayFragment extends Fragment implements Playlist_RecyclerViewInter
         }
     }
 
-//    public void toggleAPI(View v) {
-//        Button b = (Button) v;
-//        String currentState = b.getText().toString();
-//        if (currentState.equals("Play")) {mSpotifyAppRemote.getPlayerApi().resume(); b.setText(R.string.pause);}
-//        else {mSpotifyAppRemote.getPlayerApi().pause(); b.setText(R.string.play);}
-////        if (b.getText().toString().equals("Play")) {
-////
-////        }
-//    }
+    public void toggleAPI(View v) {
+        SpotifyAppRemote mSpotifyAppRemote = mainActivity.getSpotifyAppRemote();
+
+        if (mSpotifyAppRemote == null) {
+            Toast.makeText(getContext(), "Spotify Remote not connected", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        android.widget.Button b = (android.widget.Button) v;
+        String currentState = b.getText().toString();
+
+        if (currentState.equals("Play")) {
+            mSpotifyAppRemote.getPlayerApi().resume();
+            b.setText(R.string.pause);
+        } else {
+            mSpotifyAppRemote.getPlayerApi().pause();
+            b.setText(R.string.play);
+        }
+    }
 }

--- a/app/src/main/java/com/ca/tunaro/SelectedPlaylistHolder.java
+++ b/app/src/main/java/com/ca/tunaro/SelectedPlaylistHolder.java
@@ -11,6 +11,7 @@ public class SelectedPlaylistHolder {
     private static SelectedPlaylistHolder instance;
     private PlaylistModel selectedPlaylist;
     private SpotifyApi spotifyApi;
+    private MainActivity mainActivity;
     private SpotifyAppRemote mSpotifyAppRemote;
 
     private SelectedPlaylistHolder() {}
@@ -22,10 +23,11 @@ public class SelectedPlaylistHolder {
         return instance;
     }
 
-    public void setSelectedPlaylist(PlaylistModel playlist, SpotifyApi api, SpotifyAppRemote appRemote) {
+    public void setSelectedPlaylist(PlaylistModel playlist, SpotifyApi api, SpotifyAppRemote appRemote, MainActivity activity) {
         this.selectedPlaylist = playlist;
         this.spotifyApi = api;
         this.mSpotifyAppRemote = appRemote;
+        this.mainActivity = activity;
     }
 
     public PlaylistModel getSelectedPlaylist() {
@@ -40,9 +42,14 @@ public class SelectedPlaylistHolder {
         return mSpotifyAppRemote;
     }
 
+    public MainActivity getMainActivity() {
+        return mainActivity;
+    }
+
     public void clearSelectedPlaylist() {
         selectedPlaylist = null;
         spotifyApi = null;
         mSpotifyAppRemote = null;
+        mainActivity = null;
     }
 }

--- a/app/src/main/java/com/ca/tunaro/SongView.java
+++ b/app/src/main/java/com/ca/tunaro/SongView.java
@@ -1,6 +1,7 @@
 package com.ca.tunaro;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -189,33 +190,52 @@ public class SongView extends AppCompatActivity {
 
     private void playSong() {
         SpotifyAppRemote mSpotifyAppRemote = SelectedPlaylistHolder.getInstance().getSpotifyAppRemote();
+        MainActivity mainActivity = SelectedPlaylistHolder.getInstance().getMainActivity();
 
-        if (mSpotifyAppRemote != null && selectedSong != null) {
-            // Play the song
-            mSpotifyAppRemote.getPlayerApi().play(selectedSong.getUri());
+        // Try to reconnect Spotify if MainActivity is available
+        if (mainActivity != null && !mSpotifyAppRemote.isConnected()) {
+            Toast.makeText(this, "Attempting to reconnect to Spotify...", Toast.LENGTH_SHORT).show();
+            // Call a method in MainActivity to reconnect
+            mainActivity.connectSpotifyAppRemote();
+        }
 
-            // Create a "Date Listened" note
-            String currentDate = new java.text.SimpleDateFormat("dd-MM-yyyy HH:mm")
-                    .format(new java.util.Date());
-            SongNote note = new SongNote(
-                    selectedSong.getId(),
-                    SongNote.NoteType.DATE_LISTENED.getDisplayName(),
-                    currentDate
-            );
-
-            // Save to database
-            dbHelper.addNote(note);
-
-            // Refresh notes display
-            loadExistingNotes();
-
-            Toast.makeText(this, "Playing " + selectedSong.getName(),
-                    Toast.LENGTH_SHORT).show();
+        if (mSpotifyAppRemote != null && mSpotifyAppRemote.isConnected() && selectedSong != null) {
+            try {
+                // Play the song
+                mSpotifyAppRemote.getPlayerApi().play(selectedSong.getUri())
+                        .setResultCallback(empty -> {
+                            // Create a "Date Listened" note
+//                            String currentDate = new java.text.SimpleDateFormat("dd-MM-yyyy HH:mm")
+//                                    .format(new java.util.Date());
+//                            SongNote note = new SongNote(
+//                                    selectedSong.getId(),
+//                                    SongNote.NoteType.DATE_LISTENED.getDisplayName(),
+//                                    currentDate
+//                            );
+//
+//                            // Save to database
+//                            dbHelper.addNote(note);
+//
+//                            // Refresh notes display
+//                            loadExistingNotes();
+//
+                            Toast.makeText(this, "Playing " + selectedSong.getName(),
+                                    Toast.LENGTH_SHORT).show();
+                        })
+                        .setErrorCallback(throwable -> {
+                            Toast.makeText(this, "Error playing song: " + throwable.getMessage(),
+                                    Toast.LENGTH_SHORT).show();
+                            Log.e("SongView", "PlaybackError: " + throwable.getMessage());
+                        });
+            } catch (Exception e) {
+                Log.e("SongView", "PlaybackException: " + e.getMessage());
+            }
         } else {
             Toast.makeText(this, "Unable to play song. Please check Spotify connection.",
                     Toast.LENGTH_SHORT).show();
         }
     }
+
 
     // Display methods
     private void showEditDialog(final SongNote note) {


### PR DESCRIPTION
The SpotifyAppRemote connection was being disconnected in MainActivity.onStop() even during internal navigation between activities. Modified to only disconnect when the app is truly closing by checking isFinishing() condition.