### PR TITLE
Add quick play via long-press on album art

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
         minSdk = 28
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0"
+        versionName = "2.16"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -372,4 +372,21 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         Intent intent = new Intent(this, SongView.class);
         startActivity(intent);
     }
+
+    // Quick play functionality
+    public void onAlbumCoverLongClick(int position) {
+        SongModel clickedSong = adapter.getSongs().get(position);
+
+        // Play the song immediately using PlaybackManager
+        if (!playbackManager.isConnected()) {
+            Toast.makeText(this, "Connecting to Spotify...", Toast.LENGTH_SHORT).show();
+            playbackManager.connectSpotify(this, () -> {
+                playbackManager.playSong(clickedSong);
+                Toast.makeText(this, "Playing " + clickedSong.getName(), Toast.LENGTH_SHORT).show();
+            });
+        } else {
+            playbackManager.playSong(clickedSong);
+            Toast.makeText(this, "Playing " + clickedSong.getName(), Toast.LENGTH_SHORT).show();
+        }
+    }
 }

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -116,6 +116,7 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
             hasSnippetsIcon = itemView.findViewById(R.id.hasSnippetsIcon);
             contextualInfoView = itemView.findViewById(R.id.contextualInfoView);
 
+            // Open SongView on click
             itemView.setOnClickListener(view -> {
                 if (recyclerViewInterface != null) {
                     int position = getAdapterPosition();
@@ -124,6 +125,20 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                         recyclerViewInterface.onItemClick(position, itemView);
                     }
                 }
+            });
+
+            // Long press on album cover for quick play
+            imageCoverView.setOnLongClickListener(view -> {
+                if (recyclerViewInterface != null) {
+                    int position = getAdapterPosition();
+                    if (position != RecyclerView.NO_POSITION) {
+                        if (recyclerViewInterface instanceof PlaylistView) {
+                            recyclerViewInterface.onAlbumCoverLongClick(position);
+                        }
+                        return true;
+                    }
+                }
+                return false;
             });
         }
     }

--- a/app/src/main/java/com/ca/tunaro/interfaces/Song_RecyclerViewInterface.java
+++ b/app/src/main/java/com/ca/tunaro/interfaces/Song_RecyclerViewInterface.java
@@ -4,4 +4,7 @@ import android.view.View;
 
 public interface Song_RecyclerViewInterface {
     void onItemClick(int position, View itemView);
+
+    // Quick play functionality
+    default void onAlbumCoverLongClick(int position) {}
 }

--- a/app/src/main/res/layout/song_recycler_view_row.xml
+++ b/app/src/main/res/layout/song_recycler_view_row.xml
@@ -30,6 +30,8 @@
                 android:layout_height="70dp"
                 android:contentDescription="@string/songAlbumCoverImage"
                 android:padding="5dp"
+                android:background="?attr/selectableItemBackground"
+                android:longClickable="true"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintHeight_percent="0.6"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
This commit introduces a quick play feature that allows users to start playing a song by long-pressing its album cover in the `PlaylistView`.

- Incremented app version to 2.16.