### PR TITLE
Refactor Spotify API access and song popularity fetching

### DIFF
--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -92,7 +92,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         // Get SpotifyApi instance from MainActivity
         SpotifyApi spotifyApi = null;
         try {
-            spotifyApi = SelectedPlaylistHolder.getInstance().getMainActivity().getSpotifyApi();
+            spotifyApi = MainActivity.getInstance().getSpotifyApi();
             if (spotifyApi == null) throw new Exception("SpotifyApi not available");
         } catch (Exception e) {
             finish();
@@ -112,7 +112,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
                         showLoading(false, songs.size(), selectedPlaylist.getSongCount());
                         adapter = new Song_RecyclerViewAdapter(this, this, this, selectedPlaylist.getSongs());
                         recyclerView.setAdapter(adapter);
-                        setupSearch();  // Call this after adapter is initialized
+                        setupSearch();
                         setupSorting();
                     });
                 })

--- a/app/src/main/java/com/ca/tunaro/activites/SongView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SongView.java
@@ -112,6 +112,18 @@ public class SongView extends BaseActivity {
         albumView.setText(albumName);
         durationView.setText(duration);
         if (!popularity.equals("0")) popularityView.setText("Popularity: " + popularity + "%");
+        else selectedSong.fetchPopularityAsync(new SongModel.PopularityCallback() {
+        // Fetch it from Spotify, asynchronously
+            @Override
+            public void onPopularityFetched(int popularity) {
+                popularityView.setText("Popularity: " + popularity + "%");
+            }
+
+            @Override
+            public void onError(String error) {
+
+            }
+        });
     }
 
     private void setupTabs() {

--- a/app/src/main/java/com/ca/tunaro/models/SongModel.java
+++ b/app/src/main/java/com/ca/tunaro/models/SongModel.java
@@ -1,7 +1,10 @@
 package com.ca.tunaro.models;
 
+import com.ca.tunaro.activites.MainActivity;
+
 import java.util.Date;
 
+import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
 
 public class SongModel {
@@ -78,6 +81,45 @@ public class SongModel {
 
     public int getPopularity() {
         return popularity;
+    }
+
+    public void fetchPopularityAsync(PopularityCallback callback) {
+        // Check if popularity is already available
+        if (popularity != 0) {
+            if (callback != null) {
+                callback.onPopularityFetched(popularity);
+            }
+            return;
+        }
+
+        MainActivity mainActivity = MainActivity.getInstance();
+        if (mainActivity == null || mainActivity.getSpotifyApi() == null) {
+            if (callback != null) {
+                callback.onError("Spotify API not available");
+            }
+            return;
+        }
+
+        mainActivity.getSpotifyApi().getTrack(this.id)
+                .build()
+                .executeAsync()
+                .thenAccept(track -> {
+                    this.popularity = track.getPopularity();
+                    if (callback != null) {
+                        callback.onPopularityFetched(this.popularity);
+                    }
+                })
+                .exceptionally(throwable -> {
+                    if (callback != null) {
+                        callback.onError("Failed to fetch popularity: " + throwable.getMessage());
+                    }
+                    return null;
+                });
+    }
+
+    public interface PopularityCallback {
+        void onPopularityFetched(int popularity);
+        void onError(String error);
     }
 
     public String getAlbumName() {


### PR DESCRIPTION
A new asynchronous method `fetchPopularityAsync` has been added to `SongModel`. This allows fetching a song's popularity from Spotify if it's not already available locally.