### PR TITLE
87 single-account enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Files for the ART/Dalvik VM
 *.dex
 
+# AI files
+CLAUDE.md
+
 # Java class files
 *.class
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,10 @@
             android:exported="false"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".activites.AccountMismatchActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".activites.PlaylistsActivity"
             android:exported="false"
             android:screenOrientation="portrait" />

--- a/app/src/main/java/com/ca/tunaro/activites/AccountMismatchActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/AccountMismatchActivity.java
@@ -1,0 +1,168 @@
+package com.ca.tunaro.activites;
+
+import android.app.ProgressDialog;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.ca.tunaro.R;
+import com.ca.tunaro.database.DatabaseHelper;
+
+public class AccountMismatchActivity extends AppCompatActivity {
+    private static final String TAG = "AccountMismatchActivity";
+
+    public static final String EXTRA_EXPECTED_USER = "expected_user";
+    public static final String EXTRA_ACTUAL_USER = "actual_user";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_account_mismatch);
+
+        String expectedUser = getIntent().getStringExtra(EXTRA_EXPECTED_USER);
+        String actualUser = getIntent().getStringExtra(EXTRA_ACTUAL_USER);
+
+        TextView accountInfo = findViewById(R.id.account_info);
+        if (expectedUser != null && actualUser != null) {
+            accountInfo.setText("Expected: " + expectedUser + "\nSigned in as: " + actualUser);
+        }
+
+        Button backupButton = findViewById(R.id.backup_button);
+        Button resetButton = findViewById(R.id.reset_button);
+        Button exitButton = findViewById(R.id.exit_button);
+
+        backupButton.setOnClickListener(v -> exportData());
+
+        resetButton.setOnClickListener(v -> {
+            new AlertDialog.Builder(this)
+                    .setTitle("Reset App Data")
+                    .setMessage("Would you like to export your data before resetting?")
+                    .setPositiveButton("Export First", (dialog, which) -> {
+                        exportDataThenReset();
+                    })
+                    .setNegativeButton("Reset Now", (dialog, which) -> {
+                        confirmReset();
+                    })
+                    .setNeutralButton("Cancel", null)
+                    .show();
+        });
+
+        exitButton.setOnClickListener(v -> {
+            finishAffinity();
+        });
+    }
+
+    private void exportData() {
+        String fileName = "tunaro_backup_" +
+                new java.text.SimpleDateFormat("yyyyMMdd_HHmmss", java.util.Locale.getDefault()).format(new java.util.Date()) +
+                ".json";
+        exportLauncher.launch(fileName);
+    }
+
+    private final ActivityResultLauncher<String> exportLauncher = registerForActivityResult(
+            new ActivityResultContracts.CreateDocument("application/json"),
+            uri -> {
+                if (uri != null) {
+                    ProgressDialog progressDialog = new ProgressDialog(this);
+                    progressDialog.setMessage("Exporting data...");
+                    progressDialog.setCancelable(false);
+                    progressDialog.show();
+
+                    new Thread(() -> {
+                        try {
+                            DatabaseHelper.writeExportToUri(this, uri);
+                            runOnUiThread(() -> {
+                                progressDialog.dismiss();
+                                Toast.makeText(this, "Data exported successfully!", Toast.LENGTH_SHORT).show();
+                            });
+                        } catch (Exception e) {
+                            runOnUiThread(() -> {
+                                progressDialog.dismiss();
+                                Toast.makeText(this, "Export failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                            });
+                        }
+                    }).start();
+                }
+            }
+    );
+
+    private boolean pendingReset = false;
+
+    private void exportDataThenReset() {
+        pendingReset = true;
+        String fileName = "tunaro_backup_" +
+                new java.text.SimpleDateFormat("yyyyMMdd_HHmmss", java.util.Locale.getDefault()).format(new java.util.Date()) +
+                ".json";
+        exportThenResetLauncher.launch(fileName);
+    }
+
+    private final ActivityResultLauncher<String> exportThenResetLauncher = registerForActivityResult(
+            new ActivityResultContracts.CreateDocument("application/json"),
+            uri -> {
+                if (uri != null) {
+                    ProgressDialog progressDialog = new ProgressDialog(this);
+                    progressDialog.setMessage("Exporting data...");
+                    progressDialog.setCancelable(false);
+                    progressDialog.show();
+
+                    new Thread(() -> {
+                        try {
+                            DatabaseHelper.writeExportToUri(this, uri);
+                            runOnUiThread(() -> {
+                                progressDialog.dismiss();
+                                Toast.makeText(this, "Data exported successfully!", Toast.LENGTH_SHORT).show();
+                                performReset();
+                            });
+                        } catch (Exception e) {
+                            runOnUiThread(() -> {
+                                progressDialog.dismiss();
+                                Toast.makeText(this, "Export failed: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                            });
+                        }
+                    }).start();
+                }
+            }
+    );
+
+    private void confirmReset() {
+        new AlertDialog.Builder(this)
+                .setTitle("Are you sure?")
+                .setMessage("This will permanently delete all app data including notes, snippets, and listening history.")
+                .setPositiveButton("Reset", (dialog, which) -> performReset())
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void performReset() {
+        // Delete the database
+        deleteDatabase("TunaroDB");
+
+        // Clear all SharedPreferences
+        getSharedPreferences("SpotifyPrefs", MODE_PRIVATE).edit().clear().apply();
+        getSharedPreferences("TunaroPrefs", MODE_PRIVATE).edit().clear().apply();
+        getSharedPreferences("AutoFetcherPrefs", MODE_PRIVATE).edit().clear().apply();
+
+        Log.d(TAG, "App data reset complete");
+        Toast.makeText(this, "App data has been reset", Toast.LENGTH_SHORT).show();
+
+        // Restart app from MainActivity (fresh start with current account)
+        Intent intent = new Intent(this, MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        startActivity(intent);
+        finish();
+    }
+
+    @Override
+    public void onBackPressed() {
+        // Prevent going back to the splash screen
+        finishAffinity();
+    }
+}

--- a/app/src/main/java/com/ca/tunaro/activites/HomeActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/HomeActivity.java
@@ -1,6 +1,7 @@
 package com.ca.tunaro.activites;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.ImageView;
@@ -8,6 +9,7 @@ import android.widget.Toast;
 
 import androidx.cardview.widget.CardView;
 
+import com.bumptech.glide.Glide;
 import com.ca.tunaro.BaseActivity;
 import com.ca.tunaro.R;
 import com.google.android.material.button.MaterialButton;
@@ -36,6 +38,20 @@ public class HomeActivity extends BaseActivity {
         playEarliestButton = findViewById(R.id.play_earliest_button);
 
         setupClickListeners();
+        setupProfileImage();
+    }
+
+    private void setupProfileImage() {
+        ImageView profileImage = findViewById(R.id.user_profile_image);
+        SharedPreferences prefs = getSharedPreferences("SpotifyPrefs", MODE_PRIVATE);
+        String imageUrl = prefs.getString("spotify_profile_image_url", null);
+        if (imageUrl != null && profileImage != null) {
+            Glide.with(this)
+                    .load(imageUrl)
+                    .circleCrop()
+                    .placeholder(R.drawable.playlist_placeholder)
+                    .into(profileImage);
+        }
     }
 
     private void setupClickListeners() {

--- a/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
@@ -85,6 +85,17 @@ public class MainActivity extends AppCompatActivity {
                 REDIRECT_URI.toString()
         );
 
+        // Restore session from saved tokens (silent recovery)
+        if (tryRestoreSession()) {
+            Log.d(TAG, "Session restored from saved tokens");
+            connectSpotifyAppRemote();
+            performInitialDeviceCheck();
+            performAutomaticFetch();
+            Intent intent = new Intent(MainActivity.this, HomeActivity.class);
+            startActivity(intent);
+            return;
+        }
+
         // Initialize the CompletableFuture
         authenticationFuture = new CompletableFuture<>();
 
@@ -138,7 +149,7 @@ public class MainActivity extends AppCompatActivity {
         AuthorizationRequest.Builder builder =
                 new AuthorizationRequest.Builder(CLIENT_ID, AuthorizationResponse.Type.CODE, REDIRECT_URI.toString());
         // Set permissions and scope
-        builder.setScopes(new String[]{"app-remote-control", "streaming", "playlist-read-private", "playlist-modify-private", "user-read-playback-state", "user-read-recently-played"});
+        builder.setScopes(new String[]{"app-remote-control", "streaming", "playlist-read-private", "playlist-modify-private", "user-read-playback-state", "user-read-recently-played", "user-read-private"});
         AuthorizationRequest request = builder.build();
 
         AuthorizationClient.openLoginActivity(this, REQUEST_CODE, request);
@@ -157,6 +168,34 @@ public class MainActivity extends AppCompatActivity {
         }), executor);
     }
 
+    private boolean tryRestoreSession() {
+        SharedPreferences spotifyPrefs = getSharedPreferences("SpotifyPrefs", MODE_PRIVATE);
+        String accessToken = spotifyPrefs.getString("spotify_access_token", null);
+        String refreshToken = spotifyPrefs.getString("spotify_refresh_token", null);
+
+        SharedPreferences tunaroPrefs = getSharedPreferences("TunaroPrefs", MODE_PRIVATE);
+        String savedUserId = tunaroPrefs.getString("spotify_user_id", null);
+        String savedDisplayName = spotifyPrefs.getString("spotify_display_name", null);
+
+        if (accessToken == null || refreshToken == null || savedUserId == null) {
+            return false;
+        }
+
+        // Restore session state
+        spotifyApi = new SpotifyApi.Builder()
+                .setClientId(CLIENT_ID)
+                .setClientSecret(CLIENT_SECRET)
+                .setRedirectUri(REDIRECT_URI)
+                .setAccessToken(accessToken)
+                .setRefreshToken(refreshToken)
+                .build();
+        userID = savedUserId;
+        userDisplayName = savedDisplayName;
+
+        Log.d(TAG, "Restored session for user: " + userDisplayName);
+        return true;
+    }
+
     public void connectSpotifyAppRemote() {
         PlaybackManager.getInstance().connectSpotify(this, null);
     }
@@ -169,11 +208,49 @@ public class MainActivity extends AppCompatActivity {
                     userID = user.getId();
                     userDisplayName = user.getDisplayName();
 
+                    // Save profile info to SharedPreferences for use by other activities
+                    String imageUrl = user.getImages().length > 0 ? user.getImages()[0].getUrl() : null;
+                    SharedPreferences prefs = getSharedPreferences("SpotifyPrefs", MODE_PRIVATE);
+                    prefs.edit()
+                            .putString("spotify_display_name", userDisplayName)
+                            .putString("spotify_profile_image_url", imageUrl)
+                            .apply();
+
+                    // Save userID to SharedPreferences so it survives if this Activity is destroyed
+                    SharedPreferences tunaroPrefs = getSharedPreferences("TunaroPrefs", MODE_PRIVATE);
+                    tunaroPrefs.edit().putString("spotify_user_id", userID).apply();
+
+                    // Check for account mismatch
+                    String originalUserId = tunaroPrefs.getString("original_spotify_user_id", null);
+                    if (originalUserId == null) {
+                        // First-ever login — record this user as the original
+                        tunaroPrefs.edit().putString("original_spotify_user_id", userID).apply();
+                    } else if (!userID.equals(originalUserId)) {
+                        // Different account signed in — show mismatch screen
+                        runOnUiThread(() -> {
+                            if (loadingDialog != null && loadingDialog.isShowing()) {
+                                loadingDialog.dismiss();
+                            }
+                            Intent mismatchIntent = new Intent(MainActivity.this, AccountMismatchActivity.class);
+                            mismatchIntent.putExtra(AccountMismatchActivity.EXTRA_EXPECTED_USER, originalUserId);
+                            mismatchIntent.putExtra(AccountMismatchActivity.EXTRA_ACTUAL_USER, userDisplayName != null ? userDisplayName : userID);
+                            mismatchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                            startActivity(mismatchIntent);
+                            finish();
+                        });
+                        throw new RuntimeException("Account mismatch");
+                    }
+
                     runOnUiThread(() -> showToast("Logged in as " + userDisplayName));
                 })
                 .exceptionally(throwable -> {
-                    runOnUiThread(() -> showToast("Error: " + throwable.getMessage()));
-                    return null;
+                    String message = throwable.getMessage();
+                    // Don't show error toast for account mismatch (already handled)
+                    if (message != null && message.contains("Account mismatch")) {
+                        return null;
+                    }
+                    runOnUiThread(() -> showToast("Failed to load profile: " + message));
+                    throw new RuntimeException("Failed to load profile", throwable);
                 });
     }
 

--- a/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
+++ b/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
@@ -9,7 +9,6 @@ import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
 import android.util.Log;
 
-import com.ca.tunaro.activites.MainActivity;
 import com.ca.tunaro.models.ListenHistoryEntry;
 import com.ca.tunaro.models.SongNote;
 import com.ca.tunaro.models.SongSnippet;

--- a/app/src/main/java/com/ca/tunaro/services/AutomaticFetcher.java
+++ b/app/src/main/java/com/ca/tunaro/services/AutomaticFetcher.java
@@ -128,14 +128,14 @@ public class AutomaticFetcher {
 
     private void storeCredentials(String username, String password, String jwt, String apiKey) {
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
-        prefs.edit()
+        SharedPreferences.Editor editor = prefs.edit()
                 .putString(PREF_USERNAME, username)
                 .putString(PREF_PASSWORD, password)
                 .putString(PREF_JWT_TOKEN, jwt)
                 .putString(PREF_API_KEY, apiKey)
                 .putBoolean(PREF_REGISTERED, true)
-                .putBoolean(PREF_ENABLED, true)
-                .apply();
+                .putBoolean(PREF_ENABLED, true);
+        editor.apply();
     }
 
     public void setEnabled(boolean enabled) {

--- a/app/src/main/java/com/ca/tunaro/services/ServerApiClient.java
+++ b/app/src/main/java/com/ca/tunaro/services/ServerApiClient.java
@@ -146,6 +146,7 @@ public class ServerApiClient {
         String response = makeRequest(endpoint, "DELETE", null, jwtToken);
         Log.d(TAG, "API key revoked: " + response);
     }
+
     //#endregion
 
     //#region Spotify Endpoints
@@ -232,7 +233,7 @@ public class ServerApiClient {
             }
 
             if (body != null && !body.isEmpty() &&
-                (method.equals("POST") || method.equals("PUT"))) {
+                (method.equals("POST") || method.equals("PUT") || method.equals("PATCH"))) {
                 connection.setDoOutput(true);
                 try (OutputStream os = connection.getOutputStream()) {
                     byte[] input = body.getBytes(StandardCharsets.UTF_8);

--- a/app/src/main/res/layout/activity_account_mismatch.xml
+++ b/app/src/main/res/layout/activity_account_mismatch.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/dark_blue"
+    android:padding="32dp">
+
+    <TextView
+        android:id="@+id/title_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:textColor="@color/white"
+        android:textSize="48sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="60dp" />
+
+    <TextView
+        android:id="@+id/mismatch_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:gravity="center"
+        android:text="A different Spotify account is signed in.\n\nThis app is linked to a different account. Please sign in with the correct account, or use the options below."
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        android:lineSpacingExtra="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title_text" />
+
+    <TextView
+        android:id="@+id/account_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:textColor="#AAAAAA"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/mismatch_message" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/account_info"
+        app:layout_constraintVertical_bias="0.4">
+
+        <Button
+            android:id="@+id/backup_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:text="Backup (Export) Data"
+            android:textSize="16sp" />
+
+        <Button
+            android:id="@+id/reset_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:backgroundTint="#D32F2F"
+            android:text="Reset App Data"
+            android:textColor="#FFFFFF"
+            android:textSize="16sp" />
+
+        <Button
+            android:id="@+id/exit_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Exit App"
+            android:textSize="16sp" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -35,6 +35,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageView
+        android:id="@+id/user_profile_image"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="44dp"
+        android:contentDescription="User profile"
+        android:src="@drawable/playlist_placeholder"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/home_text"
         android:layout_width="wrap_content"


### PR DESCRIPTION
Single-account enforcement with mismatch screen, profile image, and silent session restore

Replace multi-account DB support with single-account model. Detect account mismatch on login and show dedicated screen with backup, reset, and exit options. Add profile image to home screen. Restore session from saved tokens when MainActivity is garbage collected to avoid unnecessary re-auth.