### PR TITLE
49 add queues + context control when playing from playlists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ secrets.xml
 
 # OS specific
 .DS_Store
+
+# Planning docs
+STATUS.md

--- a/app/src/main/java/com/ca/tunaro/activites/HomeActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/HomeActivity.java
@@ -49,7 +49,6 @@ public class HomeActivity extends BaseActivity {
             Glide.with(this)
                     .load(imageUrl)
                     .circleCrop()
-                    .placeholder(R.drawable.playlist_placeholder)
                     .into(profileImage);
         }
     }

--- a/app/src/main/java/com/ca/tunaro/activites/LibraryActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/LibraryActivity.java
@@ -150,6 +150,7 @@ public class LibraryActivity extends BaseActivity implements Library_RecyclerVie
                             isrc = externalIds.getOrDefault("isrc", "");
                         }
 
+                        Boolean playable = track.getIsPlayable();
                         SongModel songModel = new SongModel(
                                 track.getId(),
                                 track.getName(),
@@ -159,7 +160,8 @@ public class LibraryActivity extends BaseActivity implements Library_RecyclerVie
                                 track.getPopularity(),
                                 album,
                                 isrc,
-                                null
+                                null,
+                                playable == null || playable
                         );
 
                         allSongs.add(songModel);
@@ -235,6 +237,7 @@ public class LibraryActivity extends BaseActivity implements Library_RecyclerVie
                         }
 
                         // Create SongModel from Spotify Track
+                        Boolean playable2 = track.getIsPlayable();
                         SongModel songModel = new SongModel(
                                 track.getId(),
                                 track.getName(),
@@ -244,7 +247,8 @@ public class LibraryActivity extends BaseActivity implements Library_RecyclerVie
                                 track.getPopularity(),
                                 album,
                                 isrc,
-                                null // Unnecessary for library view
+                                null, // Unnecessary for library view
+                                playable2 == null || playable2
                         );
 
                         // Set the selected song in the singleton

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -356,9 +356,6 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
 
         sortSpinner.setSelection(savedSortOption);
 
-        // Apply initial sort with contextual info
-        sortSongs(savedSortOption);
-
         updateSortDirectionIcon();
 
         // Set up click listener for sort direction

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -630,6 +630,12 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         startActivity(intent);
     }
 
+    @Override
+    public void onPlaybackStateChanged(boolean isPlaying, SongModel currentSong) {
+        super.onPlaybackStateChanged(isPlaying, currentSong);
+        if (adapter != null) adapter.notifyDataSetChanged();
+    }
+
     // Start queue from this position
     @Override
     public void onAlbumCoverClick(int position) {

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -194,6 +194,25 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
                 .transition(DrawableTransitionOptions.withCrossFade())
                 .into(imageView);
 
+        // Tap playlist cover to play from the first listed song
+        imageView.setOnClickListener(v -> {
+            ArrayList<SongModel> currentList = adapter.getSongs();
+            if (currentList == null || currentList.isEmpty()) {
+                showToast("No songs loaded yet");
+                return;
+            }
+            if (!playbackManager.isConnected()) {
+                showToast("Connecting to Spotify...");
+                playbackManager.connectSpotify(this, () -> {
+                    playbackManager.playQueue(currentList, 0);
+                    showToast("Playing from " + currentList.get(0).getName());
+                });
+            } else {
+                playbackManager.playQueue(currentList, 0);
+                showToast("Playing from " + currentList.get(0).getName());
+            }
+        });
+
         // Set up Collapsible Header
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -313,6 +332,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
             Map<String, Integer> listenCountMap = listenCountDbHelper.getListenCountsBatch(listenCountSongIds);
             adapter.updateListenCounts(listenCountMap);
         }
+
     }
 
     private void setupSorting() {
@@ -339,8 +359,8 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
 
                 // Set layout parameters to ensure text isn't clipped
                 android.view.ViewGroup.LayoutParams params = new android.view.ViewGroup.LayoutParams(
-                    android.view.ViewGroup.LayoutParams.MATCH_PARENT,
-                    android.view.ViewGroup.LayoutParams.MATCH_PARENT
+                        android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+                        android.view.ViewGroup.LayoutParams.MATCH_PARENT
                 );
                 textView.setLayoutParams(params);
 
@@ -433,7 +453,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
 
         switch (sortOption) {
             case 0: // Date Added
-                comparator = Comparator.comparing(SongModel::getDateAddedToPlaylist);
+                comparator = Comparator.comparing(SongModel::getDateAddedToPlaylist, Comparator.nullsLast(Comparator.naturalOrder()));
                 break;
             case 1: // Last Listened
                 DatabaseHelper dbHelper = new DatabaseHelper(this);
@@ -567,6 +587,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
             Map<String, Integer> listenCountMap = listenCountDbHelper.getListenCountsBatch(listenCountSongIds);
             adapter.updateListenCounts(listenCountMap);
         }
+
     }
 
     private void showShimmerLoading(boolean isLoading) {
@@ -609,11 +630,23 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         startActivity(intent);
     }
 
-    // Quick play functionality
+    // Start queue from this position
+    @Override
+    public void onAlbumCoverClick(int position) {
+        ArrayList<SongModel> currentList = adapter.getSongs();
+        if (!playbackManager.isConnected()) {
+            showToast("Connecting to Spotify...");
+            playbackManager.connectSpotify(this, () -> playbackManager.playQueue(currentList, position));
+        } else {
+            playbackManager.playQueue(currentList, position);
+        }
+    }
+
+    // Play song individually (no queue)
+    @Override
     public void onAlbumCoverLongClick(int position) {
         SongModel clickedSong = adapter.getSongs().get(position);
 
-        // Play the song immediately using PlaybackManager
         if (!playbackManager.isConnected()) {
             showToast("Connecting to Spotify...");
             playbackManager.connectSpotify(this, () -> {

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -205,10 +205,12 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
                 showToast("Connecting to Spotify...");
                 playbackManager.connectSpotify(this, () -> {
                     playbackManager.playQueue(currentList, 0);
+                    adapter.setQueueMatchesDisplay(true);
                     showToast("Playing from " + currentList.get(0).getName());
                 });
             } else {
                 playbackManager.playQueue(currentList, 0);
+                adapter.setQueueMatchesDisplay(true);
                 showToast("Playing from " + currentList.get(0).getName());
             }
         });
@@ -642,9 +644,13 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         ArrayList<SongModel> currentList = adapter.getSongs();
         if (!playbackManager.isConnected()) {
             showToast("Connecting to Spotify...");
-            playbackManager.connectSpotify(this, () -> playbackManager.playQueue(currentList, position));
+            playbackManager.connectSpotify(this, () -> {
+                playbackManager.playQueue(currentList, position);
+                adapter.setQueueMatchesDisplay(true);
+            });
         } else {
             playbackManager.playQueue(currentList, position);
+            adapter.setQueueMatchesDisplay(true);
         }
     }
 

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -37,6 +37,7 @@ import com.ca.tunaro.R;
 import com.ca.tunaro.utils.SelectedPlaylistHolder;
 import com.ca.tunaro.utils.SelectedSongHolder;
 import com.ca.tunaro.models.SongModel;
+import com.ca.tunaro.adapters.QueueLineDecoration;
 import com.ca.tunaro.adapters.Song_RecyclerViewAdapter;
 import com.ca.tunaro.interfaces.Song_RecyclerViewInterface;
 import com.google.android.material.appbar.AppBarLayout;
@@ -57,6 +58,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
 
     private PlaylistModel selectedPlaylist;
     private Song_RecyclerViewAdapter adapter;
+    private QueueLineDecoration queueLineDecoration;
 
     // Searching
     private EditText searchBar;
@@ -109,6 +111,8 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         // Initialize adapter, empty for now
         adapter = new Song_RecyclerViewAdapter(this, this, new ArrayList<>());
         recyclerView.setAdapter(adapter);
+        queueLineDecoration = new QueueLineDecoration(adapter);
+        recyclerView.addItemDecoration(queueLineDecoration);
 
         // Show loading state while fetching songs
         showShimmerLoading(true);
@@ -205,12 +209,12 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
                 showToast("Connecting to Spotify...");
                 playbackManager.connectSpotify(this, () -> {
                     playbackManager.playQueue(currentList, 0);
-                    adapter.setQueueMatchesDisplay(true);
+                    queueLineDecoration.setQueueMatchesDisplay(true);
                     showToast("Playing from " + currentList.get(0).getName());
                 });
             } else {
                 playbackManager.playQueue(currentList, 0);
-                adapter.setQueueMatchesDisplay(true);
+                queueLineDecoration.setQueueMatchesDisplay(true);
                 showToast("Playing from " + currentList.get(0).getName());
             }
         });
@@ -320,6 +324,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         int currentSortOption = sortSpinner.getSelectedItemPosition();
         applySortToList(filteredList, currentSortOption);
         adapter.updateSongs(filteredList);
+        queueLineDecoration.setQueueMatchesDisplay(false);
 
         // Update contextual info display
         adapter.updateSortContext(currentSortOption);
@@ -576,6 +581,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         // Apply sort to the list
         applySortToList(songs, sortOption);
         adapter.updateSongs(songs);
+        queueLineDecoration.setQueueMatchesDisplay(false);
 
         adapter.updateSortContext(sortOption);
 
@@ -646,11 +652,11 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
             showToast("Connecting to Spotify...");
             playbackManager.connectSpotify(this, () -> {
                 playbackManager.playQueue(currentList, position);
-                adapter.setQueueMatchesDisplay(true);
+                queueLineDecoration.setQueueMatchesDisplay(true);
             });
         } else {
             playbackManager.playQueue(currentList, position);
-            adapter.setQueueMatchesDisplay(true);
+            queueLineDecoration.setQueueMatchesDisplay(true);
         }
     }
 

--- a/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
@@ -1,7 +1,6 @@
 package com.ca.tunaro.activites;
 
 import android.app.ProgressDialog;
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.Editable;
@@ -169,10 +168,12 @@ public class SettingsActivity extends BaseActivity {
 
         deviceNameInput.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
 
             @Override
             public void afterTextChanged(Editable s) {
@@ -292,23 +293,23 @@ public class SettingsActivity extends BaseActivity {
         // Setup deregistration button
         deregisterButton.setOnClickListener(v -> {
             new androidx.appcompat.app.AlertDialog.Builder(this)
-                .setTitle("Deregister Automatic Fetcher")
-                .setMessage("This will stop automatic syncing. Your local listening history will be preserved.")
-                .setPositiveButton("Deregister", (dialog, which) -> {
-                    automaticFetcher.deregisterFetcher(new AutomaticFetcher.DeregistrationCallback() {
-                        @Override
-                        public void onSuccess() {
-                            runOnUiThread(() -> updateRegistrationStatus(false));
-                        }
+                    .setTitle("Deregister Automatic Fetcher")
+                    .setMessage("This will stop automatic syncing. Your local listening history will be preserved.")
+                    .setPositiveButton("Deregister", (dialog, which) -> {
+                        automaticFetcher.deregisterFetcher(new AutomaticFetcher.DeregistrationCallback() {
+                            @Override
+                            public void onSuccess() {
+                                runOnUiThread(() -> updateRegistrationStatus(false));
+                            }
 
-                        @Override
-                        public void onError(String error) {
-                            // Toast is shown by AutomaticFetcher
-                        }
-                    });
-                })
-                .setNegativeButton("Cancel", null)
-                .show();
+                            @Override
+                            public void onError(String error) {
+                                // Toast is shown by AutomaticFetcher
+                            }
+                        });
+                    })
+                    .setNegativeButton("Cancel", null)
+                    .show();
         });
     }
 

--- a/app/src/main/java/com/ca/tunaro/activites/SongView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SongView.java
@@ -132,6 +132,22 @@ public class SongView extends BaseActivity {
 
     private void setupAlbumCoverLongPress() {
         ImageView albumCoverImageView = findViewById(R.id.SongView_AlbumCover);
+
+        // Tap: skip to this song in the active queue, or play individually if no queue
+        albumCoverImageView.setOnClickListener(v -> {
+            if (!playbackManager.isConnected()) {
+                showToast("Connecting to Spotify...");
+                playbackManager.connectSpotify(this, () -> {
+                    playbackManager.skipToSong(selectedSong);
+                    showToast("Playing " + selectedSong.getName());
+                });
+            } else {
+                playbackManager.skipToSong(selectedSong);
+                showToast("Playing " + selectedSong.getName());
+            }
+        });
+
+        // Long-press: play individually, leaving queue intact
         albumCoverImageView.setOnLongClickListener(v -> {
             playSong();
             return true;

--- a/app/src/main/java/com/ca/tunaro/adapters/QueueLineDecoration.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/QueueLineDecoration.java
@@ -1,0 +1,70 @@
+package com.ca.tunaro.adapters;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.ca.tunaro.managers.PlaybackManager;
+import com.ca.tunaro.models.SongModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueueLineDecoration extends RecyclerView.ItemDecoration {
+    private final Paint paint;
+    private final Song_RecyclerViewAdapter adapter;
+    private boolean queueMatchesDisplay = false;
+
+    public QueueLineDecoration(Song_RecyclerViewAdapter adapter) {
+        this.adapter = adapter;
+        paint = new Paint();
+        paint.setColor(0x6632CD32);
+        paint.setStrokeWidth(4f);
+        paint.setAntiAlias(true);
+    }
+
+    public void setQueueMatchesDisplay(boolean matches) {
+        queueMatchesDisplay = matches;
+    }
+
+    @Override
+    public void onDraw(@NonNull Canvas canvas, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+        PlaybackManager pm = PlaybackManager.getInstance();
+        List<SongModel> queue = pm.getQueue();
+        int queueIndex = pm.getQueueIndex();
+        SongModel currentSong = pm.getCurrentSong();
+
+        if (!queueMatchesDisplay || queue.isEmpty() || queueIndex < 0 || currentSong == null) return;
+        if (indexInQueueByUri(queue, currentSong) != queueIndex) return;
+
+        ArrayList<SongModel> songs = adapter.getSongs();
+        int centerX = parent.getWidth() / 2;
+
+        for (int i = 0; i < parent.getChildCount() - 1; i++) {
+            View child = parent.getChildAt(i);
+            View nextChild = parent.getChildAt(i + 1);
+            int pos = parent.getChildAdapterPosition(child);
+            int nextPos = parent.getChildAdapterPosition(nextChild);
+            if (pos < 0 || nextPos < 0 || pos >= songs.size() || nextPos >= songs.size()) continue;
+
+            int songQueueIdx = indexInQueueByUri(queue, songs.get(pos));
+            int nextSongQueueIdx = indexInQueueByUri(queue, songs.get(nextPos));
+
+            if (songQueueIdx >= queueIndex && nextSongQueueIdx > queueIndex) {
+                float top = child.getBottom();
+                float bottom = nextChild.getTop() + nextChild.getHeight() / 2f;
+                canvas.drawLine(centerX, top, centerX, bottom, paint);
+            }
+        }
+    }
+
+    private int indexInQueueByUri(List<SongModel> queue, SongModel song) {
+        for (int i = 0; i < queue.size(); i++) {
+            if (queue.get(i).getUri().equals(song.getUri())) return i;
+        }
+        return -1;
+    }
+}

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -152,7 +152,17 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                 }
             });
 
-            // Long press on album cover for quick play
+            // Tap on album cover — start queue from this position
+            imageCoverView.setOnClickListener(view -> {
+                if (recyclerViewInterface != null) {
+                    int position = getAdapterPosition();
+                    if (position != RecyclerView.NO_POSITION) {
+                        recyclerViewInterface.onAlbumCoverClick(position);
+                    }
+                }
+            });
+
+            // Long press on album cover — play individually (no queue)
             imageCoverView.setOnLongClickListener(view -> {
                 if (recyclerViewInterface != null) {
                     int position = getAdapterPosition();

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -33,7 +33,6 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
     private int currentSortOption = -1; // Track current sort option
     private boolean shouldShowContextualInfo = false;
     private Map<String, Integer> listenCountMap = null; // Cached listen counts for performance
-    private boolean queueMatchesDisplay = false;
 
     public Song_RecyclerViewAdapter(Context context, Song_RecyclerViewInterface recyclerViewInterface, ArrayList<SongModel> songModels) {
         this.context = context;
@@ -67,15 +66,6 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                 ? 0xFF162B1E  // dark green tint over blueBlack
                 : 0xFF111f28);
 
-        java.util.List<SongModel> queue = pm.getQueue();
-        int queueIndex = pm.getQueueIndex();
-        boolean currentSongInQueue = queueMatchesDisplay && !queue.isEmpty() && queueIndex >= 0
-                && currentSong != null && indexInQueueByUri(queue, currentSong) == queueIndex;
-        boolean inQueue = currentSongInQueue
-                && indexInQueueByUri(queue, model) > queueIndex;
-        boolean nextAlsoInQueue = inQueue && (position + 1) < songModels.size()
-                && indexInQueueByUri(queue, songModels.get(position + 1)) > queueIndex;
-        holder.queueConnectorLine.setVisibility(nextAlsoInQueue ? View.VISIBLE : View.GONE);
 
         // Load image using Glide
         Glide.with(context)
@@ -151,7 +141,6 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
 
     public static class ViewHolder extends RecyclerView.ViewHolder {
         CardView cardView;
-        View queueConnectorLine;
         ImageView imageCoverView;
         ImageView hasNotesIcon;
         ImageView hasSnippetsIcon;
@@ -161,7 +150,6 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
         public ViewHolder(@NonNull View itemView, Song_RecyclerViewInterface recyclerViewInterface) {
             super(itemView);
             cardView = itemView.findViewById(R.id.cardView);
-            queueConnectorLine = itemView.findViewById(R.id.queueConnectorLine);
             songNameView = itemView.findViewById(R.id.songNameView);
             artistView = itemView.findViewById(R.id.artistView);
             imageCoverView = itemView.findViewById(R.id.albumCoverView);
@@ -206,21 +194,8 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
         }
     }
 
-    private int indexInQueueByUri(java.util.List<SongModel> queue, SongModel song) {
-        for (int i = 0; i < queue.size(); i++) {
-            if (queue.get(i).getUri().equals(song.getUri())) return i;
-        }
-        return -1;
-    }
-
     public void updateSongs(ArrayList<SongModel> newSongs) {
         this.songModels = newSongs;
-        queueMatchesDisplay = false;
-        notifyDataSetChanged();
-    }
-
-    public void setQueueMatchesDisplay(boolean matches) {
-        queueMatchesDisplay = matches;
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -63,6 +63,9 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
         holder.cardView.setForeground(isPlaying
                 ? context.getDrawable(R.drawable.song_active_border)
                 : null);
+        holder.cardView.setCardBackgroundColor(isPlaying
+                ? 0xFF162B1E  // dark green tint over blueBlack
+                : 0xFF111f28);
 
         java.util.List<SongModel> queue = pm.getQueue();
         int queueIndex = pm.getQueueIndex();

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -8,12 +8,14 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.ca.tunaro.database.DatabaseHelper;
 import com.ca.tunaro.R;
+import com.ca.tunaro.managers.PlaybackManager;
 import com.ca.tunaro.models.SongModel;
 import com.ca.tunaro.interfaces.Song_RecyclerViewInterface;
 import com.ca.tunaro.activites.PlaylistView;
@@ -52,6 +54,22 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
         holder.songNameView.setSelected(true); // Enable marquee
         holder.songNameView.setText(model.getName());
         holder.artistView.setText(model.getArtist());
+
+        // Active/queue state indicators
+        PlaybackManager pm = PlaybackManager.getInstance();
+        SongModel currentSong = pm.getCurrentSong();
+        boolean isPlaying = currentSong != null && currentSong.getUri().equals(model.getUri());
+        holder.cardView.setForeground(isPlaying
+                ? context.getDrawable(R.drawable.song_active_border)
+                : null);
+
+        java.util.List<SongModel> queue = pm.getQueue();
+        int queueIndex = pm.getQueueIndex();
+        boolean inQueue = !queue.isEmpty() && queueIndex >= 0
+                && indexInQueueByUri(queue, model) > queueIndex;
+        boolean nextAlsoInQueue = inQueue && (position + 1) < songModels.size()
+                && indexInQueueByUri(queue, songModels.get(position + 1)) > queueIndex;
+        holder.queueConnectorLine.setVisibility(nextAlsoInQueue ? View.VISIBLE : View.GONE);
 
         // Load image using Glide
         Glide.with(context)
@@ -126,6 +144,8 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
     }
 
     public static class ViewHolder extends RecyclerView.ViewHolder {
+        CardView cardView;
+        View queueConnectorLine;
         ImageView imageCoverView;
         ImageView hasNotesIcon;
         ImageView hasSnippetsIcon;
@@ -134,6 +154,8 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
 
         public ViewHolder(@NonNull View itemView, Song_RecyclerViewInterface recyclerViewInterface) {
             super(itemView);
+            cardView = itemView.findViewById(R.id.cardView);
+            queueConnectorLine = itemView.findViewById(R.id.queueConnectorLine);
             songNameView = itemView.findViewById(R.id.songNameView);
             artistView = itemView.findViewById(R.id.artistView);
             imageCoverView = itemView.findViewById(R.id.albumCoverView);
@@ -176,6 +198,13 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                 return false;
             });
         }
+    }
+
+    private int indexInQueueByUri(java.util.List<SongModel> queue, SongModel song) {
+        for (int i = 0; i < queue.size(); i++) {
+            if (queue.get(i).getUri().equals(song.getUri())) return i;
+        }
+        return -1;
     }
 
     public void updateSongs(ArrayList<SongModel> newSongs) {

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -33,6 +33,7 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
     private int currentSortOption = -1; // Track current sort option
     private boolean shouldShowContextualInfo = false;
     private Map<String, Integer> listenCountMap = null; // Cached listen counts for performance
+    private boolean queueMatchesDisplay = false;
 
     public Song_RecyclerViewAdapter(Context context, Song_RecyclerViewInterface recyclerViewInterface, ArrayList<SongModel> songModels) {
         this.context = context;
@@ -65,7 +66,7 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
 
         java.util.List<SongModel> queue = pm.getQueue();
         int queueIndex = pm.getQueueIndex();
-        boolean currentSongInQueue = !queue.isEmpty() && queueIndex >= 0
+        boolean currentSongInQueue = queueMatchesDisplay && !queue.isEmpty() && queueIndex >= 0
                 && currentSong != null && indexInQueueByUri(queue, currentSong) == queueIndex;
         boolean inQueue = currentSongInQueue
                 && indexInQueueByUri(queue, model) > queueIndex;
@@ -211,6 +212,12 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
 
     public void updateSongs(ArrayList<SongModel> newSongs) {
         this.songModels = newSongs;
+        queueMatchesDisplay = false;
+        notifyDataSetChanged();
+    }
+
+    public void setQueueMatchesDisplay(boolean matches) {
+        queueMatchesDisplay = matches;
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -65,7 +65,9 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
 
         java.util.List<SongModel> queue = pm.getQueue();
         int queueIndex = pm.getQueueIndex();
-        boolean inQueue = !queue.isEmpty() && queueIndex >= 0
+        boolean currentSongInQueue = !queue.isEmpty() && queueIndex >= 0
+                && currentSong != null && indexInQueueByUri(queue, currentSong) == queueIndex;
+        boolean inQueue = currentSongInQueue
                 && indexInQueueByUri(queue, model) > queueIndex;
         boolean nextAlsoInQueue = inQueue && (position + 1) < songModels.size()
                 && indexInQueueByUri(queue, songModels.get(position + 1)) > queueIndex;

--- a/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
+++ b/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
@@ -635,8 +635,6 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
         db.insert(TABLE_LISTEN_HISTORY, null, values);
         db.close();
-
-        Log.d("ListenHistory", "Added listen record for song ID: " + songId);
     }
 
     public void addListenRecordWithTimestamp(String songId, String utcTimestamp) {

--- a/app/src/main/java/com/ca/tunaro/interfaces/Song_RecyclerViewInterface.java
+++ b/app/src/main/java/com/ca/tunaro/interfaces/Song_RecyclerViewInterface.java
@@ -6,5 +6,6 @@ public interface Song_RecyclerViewInterface {
     void onItemClick(int position, View itemView);
 
     // Quick play functionality
+    default void onAlbumCoverClick(int position) {}
     default void onAlbumCoverLongClick(int position) {}
 }

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -61,6 +61,15 @@ public class PlaybackManager {
     private final Handler listenHandler = new Handler(Looper.getMainLooper());
     private Runnable listenRunnable;
 
+    // Queue
+    private List<SongModel> queue = new ArrayList<>();
+    private int queueIndex = -1;
+    // Guard: only fire advanceQueue() once per song-end
+    private boolean queueAdvancePending = false;
+    // Timestamp of last advance — suppress end-of-song check for 3s after an advance
+    // to avoid Spotify returning stale position data for the newly-started track.
+    private long lastAdvanceTimeMs = 0;
+
     //#region Snippet Playback Fields
     private boolean isSnippetMode = false;
     private boolean isSnippetPlaying = false;
@@ -81,7 +90,8 @@ public class PlaybackManager {
         void onPlaybackPositionChanged(long positionMs, long durationMs);
     }
 
-    private PlaybackManager() {}
+    private PlaybackManager() {
+    }
 
     public static synchronized PlaybackManager getInstance() {
         if (instance == null) {
@@ -191,8 +201,6 @@ public class PlaybackManager {
 
             boolean trackChanged = false;
             if (currentSong == null || !remoteTrack.uri.equals(currentSong.getUri())) {
-                // Extract ID from URI (format: spotify:track:id)
-
                 // Create a simplified SongModel from track with string artist names
                 currentSong = createSongModelFromRemoteTrack(remoteTrack, trackId, artistNames);
                 trackChanged = true;
@@ -275,7 +283,8 @@ public class PlaybackManager {
                 0, // Don't have popularity from playback
                 album,
                 "", // ISRC not available from remote track
-                null
+                null,
+                true // Assume playable — not available from remote track
         );
     }
 
@@ -285,11 +294,66 @@ public class PlaybackManager {
                     .setResultCallback(empty -> {
                         currentSong = song;
                         isPlaying = true;
+                        queueAdvancePending = false;
                         notifyPlaybackStateChanged();
                         checkPlaybackDevice();
+                        Log.i(TAG, "Now playing: " + song.getName() + " by " + String.join(", ", song.getArtist()));
                     })
-                    .setErrorCallback(throwable -> Log.e(TAG, "Error playing song: " + throwable.getMessage()));
+                    .setErrorCallback(throwable -> {
+                        Log.e(TAG, "Error playing song: " + throwable.getMessage());
+                    });
         }
+    }
+
+    public void playQueue(List<SongModel> songs, int startIndex) {
+        if (songs == null || songs.isEmpty() || startIndex < 0 || startIndex >= songs.size())
+            return;
+        queue = new ArrayList<>(songs);
+
+        // Skip unplayable songs at the start of the queue
+        while (startIndex < queue.size() && !queue.get(startIndex).isPlayable()) {
+            Log.w(TAG, "playQueue: Skipping unplayable song '" + queue.get(startIndex).getName() + "' at index " + startIndex);
+            startIndex++;
+        }
+
+        queueIndex = startIndex;
+        Log.i(TAG, "Created queue with " + songs.size() + " songs. Starting at index " + startIndex + ": " + queue.get(queueIndex).getName());
+        playSong(queue.get(queueIndex));
+    }
+
+    public void skipToSong(SongModel song) {
+        if (queue.isEmpty()) {
+            // No active queue — play individually
+            playSong(song);
+            return;
+        }
+        for (int i = 0; i < queue.size(); i++) {
+            if (queue.get(i).getUri().equals(song.getUri())) {
+                queueIndex = i;
+                playSong(queue.get(queueIndex));
+                return;
+            }
+        }
+        // Song not found in queue — play individually without touching the queue
+        playSong(song);
+    }
+
+    public void clearQueue() {
+        queue.clear();
+        queueIndex = -1;
+        queueAdvancePending = false;
+    }
+
+    public boolean hasActiveQueue() {
+        return !queue.isEmpty();
+    }
+
+    public int getQueueIndex() {
+        return queueIndex;
+    }
+
+    public List<SongModel> getQueue() {
+        return queue;
     }
 
     public void togglePlayPause() {
@@ -333,7 +397,26 @@ public class PlaybackManager {
         }
     }
 
-    // TODO Methods for next/previous track switching
+    private void advanceQueue() {
+        if (queue.isEmpty()) return;
+        int nextIndex = queueIndex + 1;
+        if (nextIndex < queue.size()) {
+            queueIndex = nextIndex;
+            SongModel next = queue.get(queueIndex);
+            if (!next.isPlayable()) {
+                Log.w(TAG, "advanceQueue: Skipping unplayable song '" + next.getName() + "' at index " + queueIndex);
+                advanceQueue();
+                return;
+            }
+            lastAdvanceTimeMs = System.currentTimeMillis();
+            Log.i(TAG, "advanceQueue: Last Song: " + (currentSong != null ? currentSong.getName() : "none") + ", Current Song: " + next.getName() + ", Queue Position: " + (queueIndex + 1) + "/" + queue.size());
+            playSong(next);
+        } else {
+            // End of queue
+            queue.clear();
+            queueIndex = -1;
+        }
+    }
 
     //#region Listeners
 
@@ -473,9 +556,9 @@ public class PlaybackManager {
                     // Add delay to ensure song loads
                     new Handler(Looper.getMainLooper()).postDelayed(() ->
                             spotifyAppRemote.getPlayerApi().pause()
-                            .setResultCallback(pauseResult ->
-                                    new Handler(Looper.getMainLooper()).postDelayed(() ->
-                                            seekToSnippetStart(snippet), 100)), 100);
+                                    .setResultCallback(pauseResult ->
+                                            new Handler(Looper.getMainLooper()).postDelayed(() ->
+                                                    seekToSnippetStart(snippet), 100)), 100);
                 })
                 .setErrorCallback(throwable -> {
                     showToast("Error playing song: " + throwable.getMessage());
@@ -579,6 +662,17 @@ public class PlaybackManager {
 
                             // Notify listeners with updated position
                             notifyPlaybackPositionChanged();
+
+                            // Queue auto-advance: when within 1500ms of the end, wait a bit before advancing so can be closer to the actual finish without cutting it off.
+                            boolean inGracePeriod = (System.currentTimeMillis() - lastAdvanceTimeMs) < 3000;
+                            if (!queue.isEmpty() && !isSnippetMode && !playerState.isPaused
+                                    && durationMs > 0 && !queueAdvancePending && !inGracePeriod
+                                    && queueIndex + 1 < queue.size()
+                                    && (durationMs - currentPositionMs) <= 1500) {
+                                Log.d(TAG, "updatePlaybackPosition: Caught end of song at " + (durationMs - currentPositionMs) + "ms remaining. Queueing advance.");
+                                queueAdvancePending = true;
+                                positionHandler.postDelayed(PlaybackManager.this::advanceQueue, 300);
+                            }
                         }
                     });
         }

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -316,6 +316,14 @@ public class PlaybackManager {
             startIndex++;
         }
 
+        if (startIndex >= queue.size()) {
+            Log.w(TAG, "playQueue: No playable songs in queue");
+            queue.clear();
+            queueIndex = -1;
+            queueAdvancePending = false;
+            return;
+        }
+
         queueIndex = startIndex;
         Log.i(TAG, "Created queue with " + songs.size() + " songs. Starting at index " + startIndex + ": " + queue.get(queueIndex).getName());
         playSong(queue.get(queueIndex));
@@ -400,14 +408,13 @@ public class PlaybackManager {
     private void advanceQueue() {
         if (queue.isEmpty()) return;
         int nextIndex = queueIndex + 1;
+        while (nextIndex < queue.size() && !queue.get(nextIndex).isPlayable()) {
+            Log.w(TAG, "advanceQueue: Skipping unplayable song '" + queue.get(nextIndex).getName() + "' at index " + nextIndex);
+            nextIndex++;
+        }
         if (nextIndex < queue.size()) {
             queueIndex = nextIndex;
             SongModel next = queue.get(queueIndex);
-            if (!next.isPlayable()) {
-                Log.w(TAG, "advanceQueue: Skipping unplayable song '" + next.getName() + "' at index " + queueIndex);
-                advanceQueue();
-                return;
-            }
             lastAdvanceTimeMs = System.currentTimeMillis();
             Log.i(TAG, "advanceQueue: Last Song: " + (currentSong != null ? currentSong.getName() : "none") + ", Current Song: " + next.getName() + ", Queue Position: " + (queueIndex + 1) + "/" + queue.size());
             playSong(next);
@@ -415,6 +422,7 @@ public class PlaybackManager {
             // End of queue
             queue.clear();
             queueIndex = -1;
+            queueAdvancePending = false;
         }
     }
 

--- a/app/src/main/java/com/ca/tunaro/models/SongModel.java
+++ b/app/src/main/java/com/ca/tunaro/models/SongModel.java
@@ -17,6 +17,7 @@ public class SongModel implements Serializable {
     Album album;
     String isrc;                // International Standard Recording Code
     Date dateAddedToPlaylist;   // added_at (for sorting by date added)
+    boolean isPlayable;         // whether the track is playable in the user's market
 
     //#region Nested class for Album
 
@@ -63,7 +64,7 @@ public class SongModel implements Serializable {
 
     //#region Constructors
 
-    public SongModel(String id, String name, String[] artists, int duration, String uri, int popularity, Album album, String isrc, Date dateAddedToPlaylist) {
+    public SongModel(String id, String name, String[] artists, int duration, String uri, int popularity, Album album, String isrc, Date dateAddedToPlaylist, boolean isPlayable) {
         this.id = id;
         this.name = name;
         this.artists = artists;
@@ -73,10 +74,11 @@ public class SongModel implements Serializable {
         this.album = album;
         this.isrc = isrc;
         this.dateAddedToPlaylist = dateAddedToPlaylist;
+        this.isPlayable = isPlayable;
     }
 
-    public SongModel(String id, String name, ArtistSimplified[] artists, int duration, String uri, int popularity, Album album, String isrc, Date dateAddedToPlaylist) {
-        this(id, name, extractArtistNames(artists), duration, uri, popularity, album, isrc, dateAddedToPlaylist);
+    public SongModel(String id, String name, ArtistSimplified[] artists, int duration, String uri, int popularity, Album album, String isrc, Date dateAddedToPlaylist, boolean isPlayable) {
+        this(id, name, extractArtistNames(artists), duration, uri, popularity, album, isrc, dateAddedToPlaylist, isPlayable);
     }
 
     //#endregion
@@ -185,6 +187,10 @@ public class SongModel implements Serializable {
 
     public String getIsrc() {
         return isrc;
+    }
+
+    public boolean isPlayable() {
+        return isPlayable;
     }
 
     public Date getDateAddedToPlaylist() {

--- a/app/src/main/java/com/ca/tunaro/utils/PlaylistSetup.java
+++ b/app/src/main/java/com/ca/tunaro/utils/PlaylistSetup.java
@@ -177,6 +177,7 @@ public class PlaylistSetup {
 
         final GetPlaylistsItemsRequest getPlaylistsItemsRequest = spotifyApi
                 .getPlaylistsItems(id)
+                .setQueryParameter("market", "from_token")
                 .offset(offset)
                 .limit(MAX_BATCH_SIZE)
                 .build();
@@ -244,6 +245,7 @@ public class PlaylistSetup {
 
                     se.michaelthelin.spotify.requests.data.tracks.GetSeveralTracksRequest getSeveralTracksRequest =
                             spotifyApi.getSeveralTracks(String.join(",", batchIds))
+                                    .setQueryParameter("market", "from_token")
                                     .build();
 
                     Track[] tracks = getSeveralTracksRequest.execute();
@@ -292,6 +294,7 @@ public class PlaylistSetup {
             isrc = externalIds.getOrDefault("isrc", "");
         }
 
+        Boolean playable = track.getIsPlayable();
         return new SongModel(
                 track.getId(),
                 track.getName(),
@@ -301,7 +304,8 @@ public class PlaylistSetup {
                 track.getPopularity(),
                 album,
                 isrc,
-                null // No playlist date for individual tracks
+                null, // No playlist date for individual tracks
+                playable == null || playable
         );
     }
 
@@ -327,6 +331,7 @@ public class PlaylistSetup {
             isrc = externalIds.getOrDefault("isrc", "");
         }
 
+        Boolean playable = track.getIsPlayable();
         return new SongModel(
                 track.getId(),
                 track.getName(),
@@ -336,7 +341,8 @@ public class PlaylistSetup {
                 track.getPopularity(),
                 album,
                 isrc,
-                playlistTrack.getAddedAt()
+                playlistTrack.getAddedAt(),
+                playable == null || playable
         );
     }
 

--- a/app/src/main/res/drawable/song_active_border.xml
+++ b/app/src/main/res/drawable/song_active_border.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/transparent" />
+    <stroke
+        android:width="2dp"
+        android:color="#6632CD32" />
+    <corners android:radius="20dp" />
+</shape>

--- a/app/src/main/res/layout/song_recycler_view_row.xml
+++ b/app/src/main/res/layout/song_recycler_view_row.xml
@@ -5,18 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <!-- Queue connector line: runs full height behind the card, centered horizontally -->
-    <View
-        android:id="@+id/queueConnectorLine"
-        android:layout_width="2dp"
-        android:layout_height="0dp"
-        android:background="#6632CD32"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <androidx.cardview.widget.CardView
         android:id="@+id/cardView"
         android:layout_width="match_parent"
@@ -134,5 +122,6 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.cardview.widget.CardView>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/song_recycler_view_row.xml
+++ b/app/src/main/res/layout/song_recycler_view_row.xml
@@ -5,6 +5,18 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
+    <!-- Queue connector line: runs full height behind the card, centered horizontally -->
+    <View
+        android:id="@+id/queueConnectorLine"
+        android:layout_width="2dp"
+        android:layout_height="0dp"
+        android:background="#6632CD32"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.cardview.widget.CardView
         android:id="@+id/cardView"
         android:layout_width="match_parent"
@@ -13,6 +25,7 @@
         android:layout_marginTop="15dp"
         android:layout_marginEnd="8dp"
         android:paddingBottom="4dp"
+        android:foreground="@android:color/transparent"
         app:cardBackgroundColor="@color/blueBlack"
         app:cardCornerRadius="20dp"
         app:cardElevation="8dp"


### PR DESCRIPTION
Users can tap on a song's album cover to start a queue from that song's position in the playlist onwards.
Users can tap and hold a song's album cover to play a song on its own, with recommendations playing after it.