### PR TITLE
Refresh Spotify access token proactively before expiry

### DIFF
--- a/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
@@ -35,11 +35,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.SpotifyHttpManager;
+import se.michaelthelin.spotify.exceptions.detailed.UnauthorizedException;
+import se.michaelthelin.spotify.requests.AbstractRequest;
 import se.michaelthelin.spotify.requests.data.users_profile.GetCurrentUsersProfileRequest;
 
 public class MainActivity extends AppCompatActivity {
@@ -600,6 +604,7 @@ public class MainActivity extends AppCompatActivity {
                             prefs.edit()
                                 .putString("spotify_access_token", newAccessToken)
                                 .putInt("spotify_expires_in", expiresIn)
+                                .putLong("spotify_expires_at", expiryTimestamp(expiresIn))
                                 .apply();
                         }
 
@@ -634,18 +639,64 @@ public class MainActivity extends AppCompatActivity {
     public CompletableFuture<String> getValidAccessToken() {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                if (spotifyApi != null && spotifyApi.getAccessToken() != null) {
-                    // Try using current token first
-                    return spotifyApi.getAccessToken();
-                } else {
-                    // Need to refresh
+                String currentToken = spotifyApi != null ? spotifyApi.getAccessToken() : null;
+                // Refresh if there's no token, or if the stored deadline has (nearly) passed.
+                if (currentToken == null || isAccessTokenExpired()) {
                     return refreshAccessToken().get();
                 }
+                return currentToken;
             } catch (Exception e) {
                 Log.e(TAG, "Error getting valid access token", e);
                 throw new RuntimeException(e);
             }
         }, executor);
+    }
+
+    /**
+     * Executes a Spotify Web API request, transparently refreshing the access token when needed.
+     *
+     * <p>Proactive: if the stored expiry deadline has (nearly) passed, the token is refreshed
+     * before the request is built. Reactive: if the request still fails with an expired-token
+     * error (e.g. the token was revoked early), it refreshes and retries once.
+     *
+     * <p>The request is supplied as a factory rather than a pre-built request because the
+     * {@code Authorization: Bearer <token>} header is baked in at build time. After a refresh we
+     * must rebuild the request so it picks up the new token from {@link #spotifyApi}.
+     *
+     * @param requestFactory builds a fresh request using the current access token (e.g.
+     *                       {@code () -> getSpotifyApi().getTrack(id).build()})
+     */
+    public <T> CompletableFuture<T> executeWithTokenRefresh(Supplier<? extends AbstractRequest<T>> requestFactory) {
+        CompletableFuture<Void> ready = isAccessTokenExpired()
+                ? refreshAccessToken().thenApply(token -> null)
+                : CompletableFuture.completedFuture(null);
+
+        return ready
+                .thenCompose(ignored -> requestFactory.get().executeAsync())
+                .handle((result, throwable) -> {
+                    if (throwable == null) {
+                        return CompletableFuture.completedFuture(result);
+                    }
+                    if (!isTokenExpired(throwable)) {
+                        return MainActivity.<T>failedFuture(throwable);
+                    }
+                    Log.d(TAG, "Access token expired during API call — refreshing and retrying once");
+                    // Refresh, then rebuild the request (new token) and try again.
+                    return refreshAccessToken().thenCompose(token -> requestFactory.get().executeAsync());
+                })
+                .thenCompose(future -> future);
+    }
+
+    private static boolean isTokenExpired(Throwable throwable) {
+        Throwable cause = (throwable instanceof CompletionException && throwable.getCause() != null)
+                ? throwable.getCause() : throwable;
+        return cause instanceof UnauthorizedException;
+    }
+
+    private static <T> CompletableFuture<T> failedFuture(Throwable throwable) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        future.completeExceptionally(throwable);
+        return future;
     }
 
     private void saveTokens(String accessToken, String refreshToken, int expiresIn) {
@@ -654,9 +705,28 @@ public class MainActivity extends AppCompatActivity {
             .putString("spotify_access_token", accessToken)
             .putString("spotify_refresh_token", refreshToken)
             .putInt("spotify_expires_in", expiresIn)
+            .putLong("spotify_expires_at", expiryTimestamp(expiresIn))
             .apply();
 
         Log.d(TAG, "Saved access token and refresh token to SharedPreferences (expires in " + expiresIn + " seconds)");
+    }
+
+    // Spotify returns expires_in (a duration in seconds); convert it to an absolute
+    // wall-clock deadline so we can tell later whether the token is still valid.
+    private static long expiryTimestamp(int expiresIn) {
+        return System.currentTimeMillis() + (expiresIn * 1000L);
+    }
+
+    // Refresh a little before the real deadline to absorb clock skew and request latency.
+    private static final long TOKEN_EXPIRY_SKEW_MS = 60_000L;
+
+    private boolean isAccessTokenExpired() {
+        SharedPreferences prefs = getSharedPreferences("SpotifyPrefs", MODE_PRIVATE);
+        long expiresAt = prefs.getLong("spotify_expires_at", 0L);
+        // No recorded expiry (e.g. token saved by an older app version) — treat as expired
+        // so we refresh once and start tracking the deadline.
+        if (expiresAt == 0L) return true;
+        return System.currentTimeMillis() >= (expiresAt - TOKEN_EXPIRY_SKEW_MS);
     }
 
     // Overload for backward compatibility when expires_in is not provided

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistsActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistsActivity.java
@@ -37,7 +37,6 @@ public class PlaylistsActivity extends BaseActivity implements Playlist_Recycler
     private SwipeRefreshLayout swipeRefreshLayout;
     private ImageView archiveToggleButton;
     private boolean showingArchived = false;
-    private boolean retried = false;
     private PopupMenu activePopupMenu;
 
     @Override
@@ -81,24 +80,7 @@ public class PlaylistsActivity extends BaseActivity implements Playlist_Recycler
         swipeRefreshLayout.setRefreshing(true);
 
         PlaylistSetup.getPlaylistData(mainActivity.getSpotifyApi())
-                .thenAccept(playlists -> {
-                    if (playlists.isEmpty() && !retried) {
-                        // Playlists may be empty due to expired token — try refreshing and retrying
-                        retried = true;
-                        mainActivity.refreshAccessToken()
-                                .thenRun(this::loadPlaylists)
-                                .exceptionally(refreshError -> {
-                                    runOnUiThread(() -> {
-                                        showToast("Error loading playlists");
-                                        swipeRefreshLayout.setRefreshing(false);
-                                    });
-                                    return null;
-                                });
-                    } else {
-                        retried = false;
-                        updateUIWithFilteredPlaylists(playlists);
-                    }
-                })
+                .thenAccept(this::updateUIWithFilteredPlaylists)
                 .exceptionally(e -> {
                     runOnUiThread(() -> {
                         showToast("Error loading playlists: " + e.getMessage());

--- a/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
@@ -207,9 +207,7 @@ public class SettingsActivity extends BaseActivity {
         }
 
         Log.d(TAG, "API: getUsersAvailableDevices");
-        mainActivity.getSpotifyApi().getUsersAvailableDevices()
-                .build()
-                .executeAsync()
+        mainActivity.executeWithTokenRefresh(() -> mainActivity.getSpotifyApi().getUsersAvailableDevices().build())
                 .thenAccept(devices -> {
                     runOnUiThread(() -> {
                         StringBuilder deviceList = new StringBuilder("Available devices:\n");

--- a/app/src/main/java/com/ca/tunaro/activites/SongView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SongView.java
@@ -189,9 +189,7 @@ public class SongView extends BaseActivity {
         String trackId = spotifyUri.substring(spotifyUri.lastIndexOf(":") + 1);
         Log.d(TAG, "API: getTrack trackId=" + trackId + " (song not yet in DB)");
 
-        mainActivity.getSpotifyApi().getTrack(trackId)
-                .build()
-                .executeAsync()
+        mainActivity.executeWithTokenRefresh(() -> mainActivity.getSpotifyApi().getTrack(trackId).build())
                 .thenAccept(track -> {
                     if (track == null) {
                         runOnUiThread(this::stopHeaderShimmer);

--- a/app/src/main/java/com/ca/tunaro/fragments/ManagePlaylistsSheet.java
+++ b/app/src/main/java/com/ca/tunaro/fragments/ManagePlaylistsSheet.java
@@ -201,10 +201,8 @@ public class ManagePlaylistsSheet extends BottomSheetDialogFragment {
 
     /** Adds the displayed song URI to the playlist on Spotify, then mirrors it locally. */
     private CompletableFuture<Void> addToPlaylist(MainActivity mainActivity, String playlistId) {
-        return mainActivity.getSpotifyApi()
-                .addItemsToPlaylist(playlistId, new String[]{songUri})
-                .build()
-                .executeAsync()
+        return mainActivity.executeWithTokenRefresh(
+                () -> mainActivity.getSpotifyApi().addItemsToPlaylist(playlistId, new String[]{songUri}).build())
                 .thenAccept(snapshot -> {
                     DatabaseHelper db = new DatabaseHelper(requireContext().getApplicationContext());
                     db.upsertSongPlaylistLink(songUri, playlistId, utcTimestamp());
@@ -233,10 +231,8 @@ public class ManagePlaylistsSheet extends BottomSheetDialogFragment {
         }
 
         final List<String> removedUris = variantsInPlaylist;
-        return mainActivity.getSpotifyApi()
-                .removeItemsFromPlaylist(playlistId, tracks)
-                .build()
-                .executeAsync()
+        return mainActivity.executeWithTokenRefresh(
+                () -> mainActivity.getSpotifyApi().removeItemsFromPlaylist(playlistId, tracks).build())
                 .thenAccept(snapshot -> {
                     DatabaseHelper db2 = new DatabaseHelper(requireContext().getApplicationContext());
                     for (String uri : removedUris) db2.markSongRemovedFromPlaylist(uri, playlistId);

--- a/app/src/main/java/com/ca/tunaro/models/SongModel.java
+++ b/app/src/main/java/com/ca/tunaro/models/SongModel.java
@@ -195,9 +195,8 @@ public class SongModel implements Serializable {
         }
 
         Log.d("SongModel", "API: getTrack trackId=" + parts[2] + " song=" + name);
-        mainActivity.getSpotifyApi().getTrack(parts[2])
-                .build()
-                .executeAsync()
+        final String trackId = parts[2];
+        mainActivity.executeWithTokenRefresh(() -> mainActivity.getSpotifyApi().getTrack(trackId).build())
                 .thenAccept(track -> {
                     this.popularity = track.getPopularity();
                     if (callback != null) callback.onPopularityFetched(this.popularity);

--- a/app/src/main/java/com/ca/tunaro/services/SongRefreshService.java
+++ b/app/src/main/java/com/ca/tunaro/services/SongRefreshService.java
@@ -3,6 +3,7 @@ package com.ca.tunaro.services;
 import android.content.Context;
 import android.util.Log;
 
+import com.ca.tunaro.activites.MainActivity;
 import com.ca.tunaro.database.DatabaseHelper;
 import com.ca.tunaro.models.SongModel;
 
@@ -29,6 +30,10 @@ public class SongRefreshService {
     public CompletableFuture<Void> refreshStaleSongs() {
         return CompletableFuture.runAsync(() -> {
             try {
+                // Ensure a non-expired token before the synchronous batch loop below, which
+                // would otherwise throw UnauthorizedException with no retry.
+                ensureFreshToken();
+
                 DatabaseHelper dbHelper = new DatabaseHelper(context);
                 Map<String, String> songsToRefresh = dbHelper.getSongsNeedingRefresh();
 
@@ -97,5 +102,18 @@ public class SongRefreshService {
                 Log.e(TAG, "Song refresh failed", e);
             }
         });
+    }
+
+    // Proactively refresh the access token if it's near expiry, then apply the valid token to
+    // this service's SpotifyApi instance (which may be a separate one from MainActivity's).
+    private void ensureFreshToken() {
+        MainActivity mainActivity = MainActivity.getInstance();
+        if (mainActivity == null) return;
+        try {
+            String token = mainActivity.getValidAccessToken().get();
+            if (token != null) spotifyApi.setAccessToken(token);
+        } catch (Exception e) {
+            Log.w(TAG, "Could not ensure fresh token before refresh, proceeding with existing", e);
+        }
     }
 }

--- a/app/src/main/java/com/ca/tunaro/utils/PlaylistSetup.java
+++ b/app/src/main/java/com/ca/tunaro/utils/PlaylistSetup.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.ca.tunaro.activites.MainActivity;
 import com.ca.tunaro.database.DatabaseHelper;
 import com.ca.tunaro.models.PlaylistModel;
 import com.ca.tunaro.models.SongModel;
@@ -63,13 +64,33 @@ public class PlaylistSetup {
         return future;
     }
 
+    // Proactively refreshes the access token if it's near expiry and applies it to the given
+    // SpotifyApi, so the (partly synchronous) request chains below don't fail with an expired
+    // token. Returns a future that completes once the token is ready; failures are swallowed so
+    // the work still proceeds with the existing token.
+    private static CompletableFuture<Void> ensureFreshToken(SpotifyApi spotifyApi) {
+        MainActivity mainActivity = MainActivity.getInstance();
+        if (mainActivity == null || spotifyApi == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return mainActivity.getValidAccessToken()
+                .thenAccept(token -> {
+                    if (token != null) spotifyApi.setAccessToken(token);
+                })
+                .exceptionally(e -> {
+                    Log.w("PlaylistSetup", "Could not ensure fresh token, proceeding with existing", e);
+                    return null;
+                });
+    }
+
     public static CompletableFuture<ArrayList<PlaylistModel>> getPlaylistData(SpotifyApi spotifyApi) {
         ArrayList<PlaylistModel> cachedPlaylists = playlistCache.getCachedPlaylists();
         if (cachedPlaylists != null) {
             return CompletableFuture.completedFuture(cachedPlaylists);
         }
 
-        return getAllPlaylists(spotifyApi, 0, new ArrayList<>())
+        return ensureFreshToken(spotifyApi)
+                .thenCompose(ignored -> getAllPlaylists(spotifyApi, 0, new ArrayList<>()))
                 .thenApply(playlists -> {
                     synchronized (lock) {
                         playlistCache.cachePlaylists(playlists);
@@ -138,7 +159,7 @@ public class PlaylistSetup {
     public static CompletableFuture<SongLoadResult> getPlaylistSongs(
             String playlistId, SpotifyApi spotifyApi, SongLoadProgressListener progressListener) {
 
-        return CompletableFuture.supplyAsync(() -> {
+        return ensureFreshToken(spotifyApi).thenCompose(ignored -> CompletableFuture.supplyAsync(() -> {
             List<String> cachedSongIds = playlistCache.getCachedPlaylistSongIds(playlistId);
             if (cachedSongIds != null && !cachedSongIds.isEmpty()) {
                 Map<String, SongModel> cachedSongsMap = songCache.getCachedSongsMap(cachedSongIds);
@@ -201,7 +222,7 @@ public class PlaylistSetup {
                 Log.e("PlaylistSetup", "Error getting songs", e);
                 return new SongLoadResult(new ArrayList<>(), false);
             }
-        });
+        }));
     }
 
     private static CompletableFuture<ArrayList<SongModel>> getAllSongs(
@@ -398,7 +419,8 @@ public class PlaylistSetup {
         if (appContext == null || spotifyApi == null) return CompletableFuture.completedFuture(null);
 
         // Fetch fresh remote track counts from Spotify before checking what needs scanning
-        return getAllPlaylists(spotifyApi, 0, new ArrayList<>())
+        return ensureFreshToken(spotifyApi)
+                .thenCompose(ignored -> getAllPlaylists(spotifyApi, 0, new ArrayList<>()))
                 .thenCompose(ignored -> runScan(spotifyApi))
                 .exceptionally(e -> {
                     Log.e("PlaylistSetup", "Failed to fetch remote track counts before scan", e);
@@ -498,7 +520,8 @@ public class PlaylistSetup {
     }
 
     public static CompletableFuture<ArrayList<PlaylistModel>> refreshPlaylists(SpotifyApi spotifyApi) {
-        return getAllPlaylists(spotifyApi, 0, new ArrayList<>())
+        return ensureFreshToken(spotifyApi)
+                .thenCompose(ignored -> getAllPlaylists(spotifyApi, 0, new ArrayList<>()))
                 .thenCompose(playlists -> {
                     synchronized (lock) {
                         playlistCache.cachePlaylists(playlists);


### PR DESCRIPTION
## Summary

The app previously had no reliable way to tell whether a Spotify access token was still valid — `saveTokens` stored only the `expires_in` *duration*, never an absolute deadline. As a result, expired-token handling was improvised per call site (proactive blanket refreshes, guessing from empty results, or nothing at all), and some paths — e.g. `SongView` fetching track metadata — would just throw `UnauthorizedException` and silently fail.

This change stores an absolute expiry deadline and checks it before every Spotify Web API call, refreshing proactively when needed, with a reactive refresh-and-retry as a safety net.

## Changes

- **Store an absolute deadline** (`spotify_expires_at`) alongside the token. `saveTokens` and the direct-write branch of `refreshAccessToken` both persist it (computed from `expires_in`).
- **`getValidAccessToken`** now refreshes when the token is missing **or** past the deadline (60s skew for clock/latency), instead of returning any non-null token.
- **`executeWithTokenRefresh(Supplier<…>)`** — new helper that refreshes proactively if the deadline passed, then runs the request, and reactively refreshes + retries once on `UnauthorizedException`. Takes a request *factory* because the SDK bakes the auth header in at `.build()` time, so the request must be rebuilt after a refresh.
- **Routed through the helper:** `SongView`, `SongModel`, `SettingsActivity`, `ManagePlaylistsSheet`.
- **Synchronous paths:** `SongRefreshService` and all four `PlaylistSetup` entry points ensure a fresh token before their blocking batch loops (`getValidAccessToken`-backed).
- **Removed** the now-redundant "empty list ⇒ expired ⇒ refresh and retry" workaround in `PlaylistsActivity`.

## Migration note

Existing installs have no `spotify_expires_at` stored; `isAccessTokenExpired()` treats a missing deadline as expired, so the first post-update request triggers one harmless refresh that re-establishes tracking.