### PR TITLE
Fix playback bar disappearing between songs

### DIFF
--- a/app/src/main/java/com/ca/tunaro/activites/BackupRestoreActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/BackupRestoreActivity.java
@@ -167,8 +167,8 @@ public class BackupRestoreActivity extends AppCompatActivity {
                 Log.d(TAG, "Resolved " + searchResolved + "/" + compositeIds.size() + " legacy composite IDs");
             }
 
-            // Build the set of track IDs whose metadata we need to fetch: every valid
-            // raw ID, plus every track ID we just resolved from a composite key.
+            // Build the set of track IDs whose metadata needs fetching: every valid
+            // raw ID, plus every track ID resolved above from a composite key.
             Set<String> validTrackIds = new LinkedHashSet<>();
             int prefilteredInvalid = 0;
             for (String id : allSongIds) {

--- a/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
@@ -712,7 +712,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     // Spotify returns expires_in (a duration in seconds); convert it to an absolute
-    // wall-clock deadline so we can tell later whether the token is still valid.
+    // wall-clock deadline to allow later checks of whether the token is still valid.
     private static long expiryTimestamp(int expiresIn) {
         return System.currentTimeMillis() + (expiresIn * 1000L);
     }
@@ -724,7 +724,7 @@ public class MainActivity extends AppCompatActivity {
         SharedPreferences prefs = getSharedPreferences("SpotifyPrefs", MODE_PRIVATE);
         long expiresAt = prefs.getLong("spotify_expires_at", 0L);
         // No recorded expiry (e.g. token saved by an older app version) — treat as expired
-        // so we refresh once and start tracking the deadline.
+        // to force one refresh and start tracking the deadline.
         if (expiresAt == 0L) return true;
         return System.currentTimeMillis() >= (expiresAt - TOKEN_EXPIRY_SKEW_MS);
     }

--- a/app/src/main/java/com/ca/tunaro/activites/SongView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SongView.java
@@ -96,7 +96,7 @@ public class SongView extends BaseActivity {
         // Upgrade to full model so Details tab has complete metadata.
         // Rows can be partial stubs: PlaybackManager writes name/duration only on
         // track change, and older writers stored album_id without the album row or
-        // artist links. Treat any of those as missing so we refetch from the API.
+        // artist links. Treat any of those as missing to force a refetch from the API.
         DatabaseHelper db = new DatabaseHelper(this);
         SongModel fullSong = db.getFullSong(selectedSong.getId());
         boolean loadingFromApi = fullSong == null

--- a/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
+++ b/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
@@ -242,9 +242,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             // Only runs from v11 — earlier versions lack the spotify_uri column on songs and fall
             // through to the drop-and-recreate path below.
             //
-            // Ordering is critical: listen_history rows use the old composite song_id, so we
-            // need the songs table (which maps song_id → spotify_uri) available during that step.
-            // All child tables are kept as _old until we have everything we need, then swapped.
+            // Ordering is critical: listen_history rows use the old composite song_id, so the
+            // songs table (which maps song_id → spotify_uri) must stay available during that step.
+            // All child tables are kept as _old until everything needed is in place, then swapped.
             //
             // Steps:
             //  1. Merge duplicate songs that share a spotify_uri into the oldest row
@@ -837,7 +837,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
     public void updatePlaylistTrackCount(String playlistId, int trackCount) {
         SQLiteDatabase db = this.getWritableDatabase();
-        // Read the current remote_track_count so we can stamp track_count to match it.
+        // Read the current remote_track_count to stamp track_count to match it.
         // This way the skip check (track_count == remote_track_count) will pass on the next
         // launch even when the playlist has duplicates (remote=1143, distinct=1128).
         int remoteCount = trackCount;

--- a/app/src/main/java/com/ca/tunaro/fragments/ManagePlaylistsSheet.java
+++ b/app/src/main/java/com/ca/tunaro/fragments/ManagePlaylistsSheet.java
@@ -220,7 +220,7 @@ public class ManagePlaylistsSheet extends BottomSheetDialogFragment {
         List<String> variantsInPlaylist = db.getActiveVariantsInPlaylist(variantUris, playlistId);
         db.close();
 
-        // Fall back to the displayed URI if we have no record of which variants are linked.
+        // Fall back to the displayed URI when there is no record of which variants are linked.
         if (variantsInPlaylist.isEmpty()) variantsInPlaylist.add(songUri);
 
         JsonArray tracks = new JsonArray();

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -292,13 +292,20 @@ public class PlaybackManager {
                 stopPositionTracking();
             }
         } else {
-            // No track playing
-
+            // No track reported. This happens transiently during track transitions
+            // (manual switch or queue auto-advance) as well as on a genuine stop.
+            // The playback bar is never torn down here: a transient null would blank
+            // the bar mid-transition, and on a real stop keeping the last song visible
+            // (so it can be resumed) is better UX than an empty gap. The bar only
+            // changes when a real track arrives to replace the current one.
+            //
+            // Tracking, however, should stop — there is no live track to poll.
             stopListenTracking();
 
-            if (isPlaying || currentSong != null) {
+            if (isPlaying) {
                 isPlaying = false;
-                currentSong = null;
+                // Keep currentSong; just reflect that nothing is actively playing so
+                // the bar shows a resumable (paused) state.
                 notifyPlaybackStateChanged();
             }
 


### PR DESCRIPTION
The playback bar was driven by currentSong being non-null. During a track transition (manual switch or queue auto-advance) Spotify briefly reports no track, which nulled currentSong and hid the bar, producing a flicker. The effect was timing-dependent: uncached songs did extra synchronous cache/DB work on the player-state callback, widening the window for the transient null callback to win the race.

Stop reacting to a transient null track: the bar is no longer torn down on a no-track player state. Position and listen tracking still stop, and isPlaying is cleared so the bar shows a resumable state, but the last song stays visible until a real track replaces it.