### PR TITLE
Queue management: swipe-to-queue + Spotify-style split queue

### DIFF
--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -58,6 +58,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
 
     private PlaylistModel selectedPlaylist;
     private Song_RecyclerViewAdapter adapter;
+    private RecyclerView recyclerView;
     private QueueLineDecoration queueLineDecoration;
     // URI of the song currently highlighted as "now playing", to avoid
     // refreshing rows on every play/pause when the song hasn't changed.
@@ -108,7 +109,7 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         setupInitialUI();
 
         // Set up RecyclerView
-        RecyclerView recyclerView = findViewById(R.id.song_recycler_view);
+        recyclerView = findViewById(R.id.song_recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
         // Initialize adapter, empty for now
@@ -677,7 +678,13 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         // when the current song changes do the old and new rows update.
         String newUri = currentSong != null ? currentSong.getUri() : null;
         if (!java.util.Objects.equals(newUri, highlightedUri)) {
-            adapter.refreshRowsForUris(highlightedUri, newUri);
+            // The now-playing highlight moved, but the queue membership of rows
+            // shifts too: the song that just started playing is no longer
+            // "upcoming", so its lime queued edge must clear. Rebind the whole
+            // list so every row re-evaluates its queued state, and refresh the
+            // connecting line decoration to match.
+            adapter.notifyDataSetChanged();
+            recyclerView.invalidateItemDecorations();
             highlightedUri = newUri;
         }
     }

--- a/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
+++ b/app/src/main/java/com/ca/tunaro/activites/PlaylistView.java
@@ -59,6 +59,9 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
     private PlaylistModel selectedPlaylist;
     private Song_RecyclerViewAdapter adapter;
     private QueueLineDecoration queueLineDecoration;
+    // URI of the song currently highlighted as "now playing", to avoid
+    // refreshing rows on every play/pause when the song hasn't changed.
+    private String highlightedUri;
 
     // Searching
     private EditText searchBar;
@@ -113,6 +116,12 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         recyclerView.setAdapter(adapter);
         queueLineDecoration = new QueueLineDecoration(adapter);
         recyclerView.addItemDecoration(queueLineDecoration);
+
+        // Swipe an album cover right to add/remove the song from the queue.
+        adapter.setOnQueueChangeListener((position, added) -> {
+            showToast(added ? "Added to queue" : "Removed from queue");
+            recyclerView.invalidateItemDecorations();
+        });
 
         // Show loading state while fetching songs
         showShimmerLoading(true);
@@ -209,12 +218,12 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
                 showToast("Connecting to Spotify...");
                 playbackManager.connectSpotify(this, () -> {
                     playbackManager.playQueue(currentList, 0);
-                    queueLineDecoration.setQueueMatchesDisplay(true);
+                    onQueueCreated();
                     showToast("Playing from " + currentList.get(0).getName());
                 });
             } else {
                 playbackManager.playQueue(currentList, 0);
-                queueLineDecoration.setQueueMatchesDisplay(true);
+                onQueueCreated();
                 showToast("Playing from " + currentList.get(0).getName());
             }
         });
@@ -650,10 +659,27 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
         overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right);
     }
 
+    // A queue was just created from this screen: queued rows need their lime
+    // edge, so refresh the whole list once and reset the highlight tracker.
+    private void onQueueCreated() {
+        queueLineDecoration.setQueueMatchesDisplay(true);
+        if (adapter != null) adapter.notifyDataSetChanged();
+        SongModel current = playbackManager.getCurrentSong();
+        highlightedUri = current != null ? current.getUri() : null;
+    }
+
     @Override
     public void onPlaybackStateChanged(boolean isPlaying, SongModel currentSong) {
         super.onPlaybackStateChanged(isPlaying, currentSong);
-        if (adapter != null) adapter.notifyDataSetChanged();
+        if (adapter == null) return;
+        // The row highlight only depends on which song is current, not on the
+        // play/paused state. A pure play<->pause toggle needs no rebind; only
+        // when the current song changes do the old and new rows update.
+        String newUri = currentSong != null ? currentSong.getUri() : null;
+        if (!java.util.Objects.equals(newUri, highlightedUri)) {
+            adapter.refreshRowsForUris(highlightedUri, newUri);
+            highlightedUri = newUri;
+        }
     }
 
     // Start queue from this position
@@ -664,11 +690,11 @@ public class PlaylistView extends BaseActivity implements Song_RecyclerViewInter
             showToast("Connecting to Spotify...");
             playbackManager.connectSpotify(this, () -> {
                 playbackManager.playQueue(currentList, position);
-                queueLineDecoration.setQueueMatchesDisplay(true);
+                onQueueCreated();
             });
         } else {
             playbackManager.playQueue(currentList, position);
-            queueLineDecoration.setQueueMatchesDisplay(true);
+            onQueueCreated();
         }
     }
 

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -283,7 +283,7 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                                     swiping = true;
                                     boolean removing = song != null
                                             && PlaybackManager.getInstance().isInQueue(song);
-                                    queueSwipeOverlay.getBackground().setTint(removing ? removeColor : addColor);
+                                    queueSwipeOverlay.getBackground().mutate().setTint(removing ? removeColor : addColor);
                                     queueSwipeIcon.setImageResource(removing
                                             ? R.drawable.ic_queue_remove : R.drawable.ic_queue_add);
                                     queueSwipeOverlay.setAlpha(1f);
@@ -308,7 +308,12 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                         case MotionEvent.ACTION_UP:
                         case MotionEvent.ACTION_CANCEL: {
                             if (!swiping) return false;
-                            swipeConsumedClick = true; // swallow the click this gesture would fire
+                            // Only a real UP fires a trailing click to swallow;
+                            // CANCEL produces no click, so leaving the flag set
+                            // would silently eat the next genuine tap.
+                            if (e.getActionMasked() == MotionEvent.ACTION_UP) {
+                                swipeConsumedClick = true;
+                            }
                             float dx = e.getRawX() - downX;
                             boolean committed = rowWidth > 0 && dx >= rowWidth * 0.18f
                                     && e.getActionMasked() == MotionEvent.ACTION_UP;
@@ -410,8 +415,11 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
         return context;
     }
 
-    // Rebind only the rows matching the given URIs (used to move the
-    // "now playing" highlight without refreshing the whole list).
+    // Rebind only the rows matching the given URIs, without refreshing the whole
+    // list. Currently unused: onPlaybackStateChanged falls back to
+    // notifyDataSetChanged because queue membership shifts across many rows on a
+    // track change. TODO: use this as a targeted optimisation once the queued
+    // state is cheap to recompute per-row.
     public void refreshRowsForUris(String... uris) {
         for (String uri : uris) {
             if (uri == null) continue;

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -274,8 +274,13 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                             float dy = e.getRawY() - downY;
                             if (!swiping) {
                                 if (dx > touchSlop && Math.abs(dx) > Math.abs(dy)) {
-                                    swiping = true;
                                     SongModel song = songAt();
+                                    // The currently-playing song can't be queued or
+                                    // removed, so ignore swipes on its row entirely.
+                                    if (song != null && isCurrentSong(song)) {
+                                        return false;
+                                    }
+                                    swiping = true;
                                     boolean removing = song != null
                                             && PlaybackManager.getInstance().isInQueue(song);
                                     queueSwipeOverlay.getBackground().setTint(removing ? removeColor : addColor);
@@ -358,6 +363,12 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
             if (adapter == null || pos == RecyclerView.NO_POSITION) return null;
             ArrayList<SongModel> songs = adapter.getSongs();
             return pos < songs.size() ? songs.get(pos) : null;
+        }
+
+        private boolean isCurrentSong(SongModel song) {
+            SongModel current = PlaybackManager.getInstance().getCurrentSong();
+            return current != null && song != null
+                    && current.getUri().equals(song.getUri());
         }
 
         private void notifyQueueChange(boolean added) {

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -1,14 +1,20 @@
 package com.ca.tunaro.adapters;
 
 import android.content.Context;
+import android.graphics.Outline;
+import android.graphics.Rect;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
+import android.view.ViewOutlineProvider;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
@@ -47,7 +53,7 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(context).inflate(R.layout.song_recycler_view_row, parent, false);
-        return new ViewHolder(view, recyclerViewInterface);
+        return new ViewHolder(view, recyclerViewInterface, this);
     }
 
     @Override
@@ -68,6 +74,17 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
         holder.cardView.setCardBackgroundColor(isPlaying
                 ? 0xFF162B1E  // dark green tint over blueBlack
                 : 0xFF111f28);
+
+        // Lime-green left edge on the album cover for songs queued (upcoming).
+        boolean queued = pm.isInQueue(model);
+        holder.showQueuedEdge(queued);
+
+        // Reset any in-progress swipe visuals when the row is (re)bound.
+        holder.swipeConsumedClick = false;
+        holder.queueSwipeOverlay.setVisibility(View.GONE);
+        holder.queueSwipeOverlay.setClipBounds(null);
+        holder.queueSwipeOverlay.setAlpha(1f);
+        holder.queueSwipeIcon.setVisibility(View.GONE);
 
 
         // Load image using Glide
@@ -149,23 +166,50 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
     public static class ViewHolder extends RecyclerView.ViewHolder {
         CardView cardView;
         ImageView imageCoverView;
+        View coverClip;
+        View queuedEdge;
+        View queueSwipeOverlay;
+        ImageView queueSwipeIcon;
         ImageView hasNotesIcon;
         ImageView hasSnippetsIcon;
         TextView songNameView, artistView;
         TextView contextualInfoView;
+        final Song_RecyclerViewAdapter adapter;
+        // Set true when a swipe gesture ends so the trailing click is ignored.
+        boolean swipeConsumedClick;
 
-        public ViewHolder(@NonNull View itemView, Song_RecyclerViewInterface recyclerViewInterface) {
+        public ViewHolder(@NonNull View itemView, Song_RecyclerViewInterface recyclerViewInterface,
+                          Song_RecyclerViewAdapter adapter) {
             super(itemView);
+            this.adapter = adapter;
             cardView = itemView.findViewById(R.id.cardView);
             songNameView = itemView.findViewById(R.id.songNameView);
             artistView = itemView.findViewById(R.id.artistView);
             imageCoverView = itemView.findViewById(R.id.albumCoverView);
+            coverClip = itemView.findViewById(R.id.coverClip);
+            queuedEdge = itemView.findViewById(R.id.queuedEdge);
+            queueSwipeOverlay = itemView.findViewById(R.id.queueSwipeOverlay);
+            queueSwipeIcon = itemView.findViewById(R.id.queueSwipeIcon);
             hasNotesIcon = itemView.findViewById(R.id.hasNotesIcon);
             hasSnippetsIcon = itemView.findViewById(R.id.hasSnippetsIcon);
             contextualInfoView = itemView.findViewById(R.id.contextualInfoView);
 
+            // Clip overlays (lime edge, swipe overlay) to the cover's rounded
+            // corners so nothing can draw outside the album art's bounds.
+            final float radius = 8 * coverClip.getResources().getDisplayMetrics().density;
+            coverClip.setOutlineProvider(new ViewOutlineProvider() {
+                @Override
+                public void getOutline(View view, Outline outline) {
+                    outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), radius);
+                }
+            });
+            coverClip.setClipToOutline(true);
+
+            attachQueueSwipe();
+
             // Open SongView on click
             itemView.setOnClickListener(view -> {
+                if (swipeConsumedClick) { swipeConsumedClick = false; return; }
                 if (recyclerViewInterface != null) {
                     int position = getAdapterPosition();
 
@@ -177,6 +221,7 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
 
             // Tap on album cover — start queue from this position
             imageCoverView.setOnClickListener(view -> {
+                if (swipeConsumedClick) { swipeConsumedClick = false; return; }
                 if (recyclerViewInterface != null) {
                     int position = getAdapterPosition();
                     if (position != RecyclerView.NO_POSITION) {
@@ -199,6 +244,142 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                 return false;
             });
         }
+
+        // Swipe anywhere on the row to the right to toggle the song in the
+        // queue. The album cover stays put; a green/red overlay wipes in from
+        // the cover's left edge, tracking the swipe distance. The action
+        // commits once the swipe passes a threshold, then the overlay eases out.
+        private void attachQueueSwipe() {
+            final int touchSlop = ViewConfiguration.get(itemView.getContext()).getScaledTouchSlop();
+            final int addColor = ContextCompat.getColor(itemView.getContext(), R.color.queueAddGreen);
+            final int removeColor = ContextCompat.getColor(itemView.getContext(), R.color.queueRemoveRed);
+
+            View.OnTouchListener swipeListener = new View.OnTouchListener() {
+                float downX, downY;
+                boolean swiping;
+                int rowWidth;
+
+                @Override
+                public boolean onTouch(View v, MotionEvent e) {
+                    switch (e.getActionMasked()) {
+                        case MotionEvent.ACTION_DOWN:
+                            downX = e.getRawX();
+                            downY = e.getRawY();
+                            swiping = false;
+                            rowWidth = itemView.getWidth();
+                            return false; // let click/long-press detection proceed
+
+                        case MotionEvent.ACTION_MOVE: {
+                            float dx = e.getRawX() - downX;
+                            float dy = e.getRawY() - downY;
+                            if (!swiping) {
+                                if (dx > touchSlop && Math.abs(dx) > Math.abs(dy)) {
+                                    swiping = true;
+                                    SongModel song = songAt();
+                                    boolean removing = song != null
+                                            && PlaybackManager.getInstance().isInQueue(song);
+                                    queueSwipeOverlay.getBackground().setTint(removing ? removeColor : addColor);
+                                    queueSwipeIcon.setImageResource(removing
+                                            ? R.drawable.ic_queue_remove : R.drawable.ic_queue_add);
+                                    queueSwipeOverlay.setAlpha(1f);
+                                    // Start fully clipped so the overlay never
+                                    // flashes across the whole cover on frame one.
+                                    queueSwipeOverlay.setClipBounds(new Rect(0, 0, 0,
+                                            queueSwipeOverlay.getHeight()));
+                                    queueSwipeOverlay.setVisibility(View.VISIBLE);
+                                    // Block the RecyclerView from stealing the gesture.
+                                    v.getParent().requestDisallowInterceptTouchEvent(true);
+                                } else {
+                                    return false;
+                                }
+                            }
+                            // Map the swipe distance across the row onto a 0..1
+                            // reveal of the (stationary) cover-sized overlay.
+                            float reveal = rowWidth > 0 ? Math.max(0f, Math.min(1f, dx / (rowWidth * 0.18f))) : 0f;
+                            applyReveal(reveal);
+                            return true;
+                        }
+
+                        case MotionEvent.ACTION_UP:
+                        case MotionEvent.ACTION_CANCEL: {
+                            if (!swiping) return false;
+                            swipeConsumedClick = true; // swallow the click this gesture would fire
+                            float dx = e.getRawX() - downX;
+                            boolean committed = rowWidth > 0 && dx >= rowWidth * 0.18f
+                                    && e.getActionMasked() == MotionEvent.ACTION_UP;
+                            if (committed) {
+                                SongModel song = songAt();
+                                if (song != null) {
+                                    PlaybackManager pm = PlaybackManager.getInstance();
+                                    boolean added;
+                                    if (pm.isInQueue(song)) {
+                                        pm.removeFromQueue(song);
+                                        added = false;
+                                    } else {
+                                        added = pm.addToQueue(song);
+                                    }
+                                    notifyQueueChange(added);
+                                }
+                            }
+                            resetSwipe();
+                            swiping = false;
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            };
+            // Attach to the whole row and to the cover, so a swipe starting
+            // anywhere (cover included) is captured while taps still work.
+            itemView.setOnTouchListener(swipeListener);
+            imageCoverView.setOnTouchListener(swipeListener);
+        }
+
+        private void showQueuedEdge(boolean show) {
+            queuedEdge.setVisibility(show ? View.VISIBLE : View.GONE);
+        }
+
+        // Reveal the overlay over the cover from the left, clipped to `progress`
+        // of the cover's width. The cover itself never moves.
+        private void applyReveal(float progress) {
+            int w = queueSwipeOverlay.getWidth();
+            int h = queueSwipeOverlay.getHeight();
+            if (w == 0 || h == 0) return;
+            int revealW = (int) (w * progress);
+            queueSwipeOverlay.setClipBounds(new Rect(0, 0, revealW, h));
+            // Fade the icon in across the swipe: 0% opacity at the start, full
+            // opacity once the overlay covers half the cover.
+            queueSwipeIcon.setVisibility(View.VISIBLE);
+            queueSwipeIcon.setAlpha(Math.min(1f, progress / 0.5f));
+        }
+
+        private SongModel songAt() {
+            int pos = getAdapterPosition();
+            if (adapter == null || pos == RecyclerView.NO_POSITION) return null;
+            ArrayList<SongModel> songs = adapter.getSongs();
+            return pos < songs.size() ? songs.get(pos) : null;
+        }
+
+        private void notifyQueueChange(boolean added) {
+            if (adapter != null) adapter.onQueueChanged(getAdapterPosition(), added);
+        }
+
+        // Fade the overlay out and refresh the queued indicator. The cover
+        // never moved, so nothing to translate back.
+        private void resetSwipe() {
+            queueSwipeIcon.animate().alpha(0f).setDuration(150).withEndAction(() -> {
+                queueSwipeIcon.setVisibility(View.GONE);
+                queueSwipeIcon.setAlpha(1f);
+            }).start();
+            queueSwipeOverlay.animate().alpha(0f).setDuration(150).withEndAction(() -> {
+                queueSwipeOverlay.setVisibility(View.GONE);
+                queueSwipeOverlay.setAlpha(1f);
+                queueSwipeOverlay.setClipBounds(null);
+                SongModel song = songAt();
+                boolean queued = song != null && PlaybackManager.getInstance().isInQueue(song);
+                showQueuedEdge(queued);
+            }).start();
+        }
     }
 
     public void updateSongs(ArrayList<SongModel> newSongs) {
@@ -212,6 +393,39 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
 
     public ArrayList<SongModel> getSongs() {
         return getSongModels();
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    // Rebind only the rows matching the given URIs (used to move the
+    // "now playing" highlight without refreshing the whole list).
+    public void refreshRowsForUris(String... uris) {
+        for (String uri : uris) {
+            if (uri == null) continue;
+            for (int i = 0; i < songModels.size(); i++) {
+                if (uri.equals(songModels.get(i).getUri())) {
+                    notifyItemChanged(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    // Notified after a swipe toggles a song in the queue.
+    public interface OnQueueChangeListener {
+        void onQueueChanged(int position, boolean added);
+    }
+
+    private OnQueueChangeListener queueChangeListener;
+
+    public void setOnQueueChangeListener(OnQueueChangeListener listener) {
+        this.queueChangeListener = listener;
+    }
+
+    void onQueueChanged(int position, boolean added) {
+        if (queueChangeListener != null) queueChangeListener.onQueueChanged(position, added);
     }
 
     public void updateSortContext(int sortOption) {

--- a/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/Song_RecyclerViewAdapter.java
@@ -267,6 +267,9 @@ public class Song_RecyclerViewAdapter extends RecyclerView.Adapter<Song_Recycler
                             downY = e.getRawY();
                             swiping = false;
                             rowWidth = itemView.getWidth();
+                            // A new touch begins: clear any stale suppression flag
+                            // so it can never outlive the gesture that set it.
+                            swipeConsumedClick = false;
                             return false; // let click/long-press detection proceed
 
                         case MotionEvent.ACTION_MOVE: {

--- a/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
+++ b/app/src/main/java/com/ca/tunaro/database/DatabaseHelper.java
@@ -1164,8 +1164,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     /**
-     * Playlists for the manage sheet, ordered favourites first then by most recently
-     * added-to. {@code containsSong} is variant-aware: it's true when any of the given
+     * Playlists for the manage sheet, ordered: playlists the song is currently in first,
+     * then favourites, then the rest by most recently added-to. {@code containsSong} is
+     * variant-aware: it's true when any of the given
      * variant URIs is actively (not removed) in the playlist, matching the panel above.
      */
     public List<ManagablePlaylist> getManagablePlaylists(List<String> variantUris, boolean includeArchived) {
@@ -1195,7 +1196,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             sql.append(" WHERE p.").append(COLUMN_IS_ARCHIVED).append(" = 0");
         }
         sql.append(" GROUP BY p.").append(COLUMN_PLAYLIST_ID)
-                .append(" ORDER BY p.").append(COLUMN_IS_FAVOURITE).append(" DESC, last_added DESC");
+                .append(" ORDER BY contains_song DESC, p.").append(COLUMN_IS_FAVOURITE).append(" DESC, last_added DESC");
 
         SQLiteDatabase db = this.getReadableDatabase();
         Cursor cursor = db.rawQuery(sql.toString(), variantUris.toArray(new String[0]));

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -68,9 +68,19 @@ public class PlaybackManager {
     private final Handler listenHandler = new Handler(Looper.getMainLooper());
     private Runnable listenRunnable;
 
-    // Queue
-    private List<SongModel> queue = new ArrayList<>();
-    private int queueIndex = -1;
+    // Queues, Spotify-style:
+    //  - primaryQueue: songs the user explicitly added (swipe-to-queue). FIFO.
+    //    Played before the playlist flow and removed once consumed.
+    //  - secondaryQueue + secondaryIndex: the playlist flow seeded by tapping a
+    //    song. secondaryIndex points at the playlist song the playback is
+    //    anchored to; it only advances when a secondary song actually plays, so
+    //    primary tracks slot in "between" playlist songs.
+    //  - history: every song that finished or was advanced past, newest last.
+    //    Plumbing for a future previous-song control.
+    private List<SongModel> primaryQueue = new ArrayList<>();
+    private List<SongModel> secondaryQueue = new ArrayList<>();
+    private int secondaryIndex = -1;
+    private final List<SongModel> history = new ArrayList<>();
     // Guard: only fire advanceQueue() once per song-end
     private boolean queueAdvancePending = false;
     // Timestamp of last advance — suppress end-of-song check for 3s after an advance
@@ -361,40 +371,45 @@ public class PlaybackManager {
         }
     }
 
+    // Seed the secondary (playlist) queue from a tapped position and start
+    // playing it. Leaves the primary (explicit) queue untouched, so explicit
+    // adds survive switching playlists and still play next.
     public void playQueue(List<SongModel> songs, int startIndex) {
         if (songs == null || songs.isEmpty() || startIndex < 0 || startIndex >= songs.size())
             return;
-        queue = new ArrayList<>(songs);
+        secondaryQueue = new ArrayList<>(songs);
 
         // Skip unplayable songs at the start of the queue
-        while (startIndex < queue.size() && !queue.get(startIndex).isPlayable()) {
-            Log.w(TAG, "playQueue: Skipping unplayable song '" + queue.get(startIndex).getName() + "' at index " + startIndex);
+        while (startIndex < secondaryQueue.size() && !secondaryQueue.get(startIndex).isPlayable()) {
+            Log.w(TAG, "playQueue: Skipping unplayable song '" + secondaryQueue.get(startIndex).getName() + "' at index " + startIndex);
             startIndex++;
         }
 
-        if (startIndex >= queue.size()) {
+        if (startIndex >= secondaryQueue.size()) {
             Log.w(TAG, "playQueue: No playable songs in queue");
-            queue.clear();
-            queueIndex = -1;
+            secondaryQueue.clear();
+            secondaryIndex = -1;
             queueAdvancePending = false;
             return;
         }
 
-        queueIndex = startIndex;
-        Log.i(TAG, "Created queue with " + songs.size() + " songs. Starting at index " + startIndex + ": " + queue.get(queueIndex).getName());
-        playSong(queue.get(queueIndex));
+        secondaryIndex = startIndex;
+        Log.i(TAG, "Created secondary queue with " + songs.size() + " songs. Starting at index " + startIndex + ": " + secondaryQueue.get(secondaryIndex).getName());
+        pushHistory(currentSong);
+        playSong(secondaryQueue.get(secondaryIndex));
     }
 
     public void skipToSong(SongModel song) {
-        if (queue.isEmpty()) {
-            // No active queue — play individually
+        if (secondaryQueue.isEmpty()) {
+            // No active playlist queue — play individually
             playSong(song);
             return;
         }
-        for (int i = 0; i < queue.size(); i++) {
-            if (queue.get(i).getUri().equals(song.getUri())) {
-                queueIndex = i;
-                playSong(queue.get(queueIndex));
+        for (int i = 0; i < secondaryQueue.size(); i++) {
+            if (secondaryQueue.get(i).getUri().equals(song.getUri())) {
+                secondaryIndex = i;
+                pushHistory(currentSong);
+                playSong(secondaryQueue.get(secondaryIndex));
                 return;
             }
         }
@@ -403,78 +418,88 @@ public class PlaybackManager {
     }
 
     public void clearQueue() {
-        queue.clear();
-        queueIndex = -1;
+        primaryQueue.clear();
+        secondaryQueue.clear();
+        secondaryIndex = -1;
         queueAdvancePending = false;
     }
 
-    // Append a song to the end of the queue. If no queue is active, seed one
-    // anchored at the currently-playing song (or the new song if nothing plays).
-    // No-op if the song is already upcoming in the queue.
+    // Add a song to the primary (explicit) queue. With nothing playing, start it
+    // immediately. No-op if the song is already queued.
     public boolean addToQueue(SongModel song) {
         if (song == null) return false;
         if (isInQueue(song)) return false;
+        if (currentSong != null && currentSong.getUri().equals(song.getUri())) return false;
 
-        if (queue.isEmpty()) {
-            queue = new ArrayList<>();
-            if (currentSong != null && !currentSong.getUri().equals(song.getUri())) {
-                queue.add(currentSong);
-                queueIndex = 0;
-            } else {
-                queueIndex = -1;
-            }
-            queue.add(song);
-        } else {
-            queue.add(song);
+        if (currentSong == null) {
+            // Nothing playing yet — just play it.
+            playSong(song);
+            Log.i(TAG, "addToQueue: nothing playing, starting '" + song.getName() + "'");
+            return true;
         }
-        Log.i(TAG, "addToQueue: '" + song.getName() + "' (queue size " + queue.size() + ")");
+
+        primaryQueue.add(song);
+        Log.i(TAG, "addToQueue: '" + song.getName() + "' (primary queue size " + primaryQueue.size() + ")");
         return true;
     }
 
-    // Remove a song from the queue by URI. The currently-playing song cannot be
-    // removed. queueIndex is shifted to keep pointing at the current song.
+    // Remove a song from whichever queue holds it. The currently-playing song
+    // cannot be removed. secondaryIndex is fixed up to stay anchored.
     public boolean removeFromQueue(SongModel song) {
-        if (song == null || queue.isEmpty()) return false;
+        if (song == null) return false;
         if (currentSong != null && currentSong.getUri().equals(song.getUri())) return false;
 
-        for (int i = 0; i < queue.size(); i++) {
-            if (queue.get(i).getUri().equals(song.getUri())) {
-                queue.remove(i);
-                if (i < queueIndex) queueIndex--;
-                if (queue.isEmpty()) {
-                    queueIndex = -1;
+        for (int i = 0; i < primaryQueue.size(); i++) {
+            if (primaryQueue.get(i).getUri().equals(song.getUri())) {
+                primaryQueue.remove(i);
+                Log.i(TAG, "removeFromQueue: '" + song.getName() + "' from primary (size " + primaryQueue.size() + ")");
+                return true;
+            }
+        }
+
+        for (int i = 0; i < secondaryQueue.size(); i++) {
+            if (secondaryQueue.get(i).getUri().equals(song.getUri())) {
+                secondaryQueue.remove(i);
+                if (i < secondaryIndex) secondaryIndex--;
+                if (secondaryQueue.isEmpty()) {
+                    secondaryIndex = -1;
                     queueAdvancePending = false;
                 }
-                Log.i(TAG, "removeFromQueue: '" + song.getName() + "' (queue size " + queue.size() + ")");
+                Log.i(TAG, "removeFromQueue: '" + song.getName() + "' from secondary (size " + secondaryQueue.size() + ")");
                 return true;
             }
         }
         return false;
     }
 
-    // True when the song is upcoming in the queue (at or after the current
-    // position). The currently-playing song is not considered "in queue" for
-    // the purposes of the swipe-to-remove affordance.
+    // True when the song is upcoming: queued in the primary queue, or ahead of
+    // the anchor in the secondary (playlist) queue. The currently-playing song
+    // is never "in queue".
     public boolean isInQueue(SongModel song) {
-        if (song == null || queue.isEmpty() || queueIndex < 0) return false;
-        for (int i = queueIndex; i < queue.size(); i++) {
-            if (queue.get(i).getUri().equals(song.getUri())) {
-                return !(currentSong != null && currentSong.getUri().equals(song.getUri()));
-            }
+        if (song == null) return false;
+        if (currentSong != null && currentSong.getUri().equals(song.getUri())) return false;
+
+        for (SongModel s : primaryQueue) {
+            if (s.getUri().equals(song.getUri())) return true;
+        }
+        for (int i = secondaryIndex + 1; i >= 0 && i < secondaryQueue.size(); i++) {
+            if (secondaryQueue.get(i).getUri().equals(song.getUri())) return true;
         }
         return false;
     }
 
     public boolean hasActiveQueue() {
-        return !queue.isEmpty();
+        return !primaryQueue.isEmpty() || !secondaryQueue.isEmpty();
     }
 
+    // The secondary (playlist) queue and its anchor, used by QueueLineDecoration
+    // to draw the connecting line down upcoming playlist songs.
     public int getQueueIndex() {
-        return queueIndex;
+        return secondaryIndex;
     }
 
     public List<SongModel> getQueue() {
-        return queue;
+        return secondaryQueue;
     }
 
     public void togglePlayPause() {
@@ -518,25 +543,69 @@ public class PlaybackManager {
         }
     }
 
+    // Whether advancing would land on a real next song (primary or secondary).
+    private boolean hasNextSong() {
+        for (SongModel s : primaryQueue) {
+            if (s.isPlayable()) return true;
+        }
+        for (int i = secondaryIndex + 1; i >= 0 && i < secondaryQueue.size(); i++) {
+            if (secondaryQueue.get(i).isPlayable()) return true;
+        }
+        return false;
+    }
+
+    // Advance to the next song: explicit (primary) adds take priority, then the
+    // playlist (secondary) flow. The song just finished is pushed to history.
     private void advanceQueue() {
-        if (queue.isEmpty()) return;
-        int nextIndex = queueIndex + 1;
-        while (nextIndex < queue.size() && !queue.get(nextIndex).isPlayable()) {
-            Log.w(TAG, "advanceQueue: Skipping unplayable song '" + queue.get(nextIndex).getName() + "' at index " + nextIndex);
+        // Primary queue first: pull the next playable explicit add off the front.
+        while (!primaryQueue.isEmpty() && !primaryQueue.get(0).isPlayable()) {
+            Log.w(TAG, "advanceQueue: Skipping unplayable primary song '" + primaryQueue.get(0).getName() + "'");
+            primaryQueue.remove(0);
+        }
+        if (!primaryQueue.isEmpty()) {
+            SongModel next = primaryQueue.remove(0);
+            lastAdvanceTimeMs = System.currentTimeMillis();
+            pushHistory(currentSong);
+            Log.i(TAG, "advanceQueue: Last Song: " + (currentSong != null ? currentSong.getName() : "none") + ", Current Song (primary): " + next.getName());
+            playSong(next);
+            return;
+        }
+
+        // Otherwise advance the playlist flow.
+        if (secondaryQueue.isEmpty()) return;
+        int nextIndex = secondaryIndex + 1;
+        while (nextIndex < secondaryQueue.size() && !secondaryQueue.get(nextIndex).isPlayable()) {
+            Log.w(TAG, "advanceQueue: Skipping unplayable song '" + secondaryQueue.get(nextIndex).getName() + "' at index " + nextIndex);
             nextIndex++;
         }
-        if (nextIndex < queue.size()) {
-            queueIndex = nextIndex;
-            SongModel next = queue.get(queueIndex);
+        if (nextIndex < secondaryQueue.size()) {
+            secondaryIndex = nextIndex;
+            SongModel next = secondaryQueue.get(secondaryIndex);
             lastAdvanceTimeMs = System.currentTimeMillis();
-            Log.i(TAG, "advanceQueue: Last Song: " + (currentSong != null ? currentSong.getName() : "none") + ", Current Song: " + next.getName() + ", Queue Position: " + (queueIndex + 1) + "/" + queue.size());
+            pushHistory(currentSong);
+            Log.i(TAG, "advanceQueue: Last Song: " + (currentSong != null ? currentSong.getName() : "none") + ", Current Song: " + next.getName() + ", Queue Position: " + (secondaryIndex + 1) + "/" + secondaryQueue.size());
             playSong(next);
         } else {
-            // End of queue
-            queue.clear();
-            queueIndex = -1;
+            // End of playlist flow.
+            pushHistory(currentSong);
+            secondaryQueue.clear();
+            secondaryIndex = -1;
             queueAdvancePending = false;
         }
+    }
+
+    // Record a song as played, for a future previous-song control. Collapses
+    // consecutive duplicates so repeated state callbacks don't bloat history.
+    private void pushHistory(SongModel song) {
+        if (song == null) return;
+        if (!history.isEmpty() && history.get(history.size() - 1).getUri().equals(song.getUri())) {
+            return;
+        }
+        history.add(song);
+    }
+
+    public List<SongModel> getHistory() {
+        return history;
     }
 
     //#region Listeners
@@ -813,9 +882,8 @@ public class PlaybackManager {
 
                             // Queue auto-advance: when within 1500ms of the end, wait a bit before advancing so can be closer to the actual finish without cutting it off.
                             boolean inGracePeriod = (System.currentTimeMillis() - lastAdvanceTimeMs) < 3000;
-                            if (!queue.isEmpty() && !isSnippetMode && !playerState.isPaused
+                            if (hasNextSong() && !isSnippetMode && !playerState.isPaused
                                     && durationMs > 0 && !queueAdvancePending && !inGracePeriod
-                                    && queueIndex + 1 < queue.size()
                                     && (durationMs - currentPositionMs) <= 1500) {
                                 Log.d(TAG, "updatePlaybackPosition: Caught end of song at " + (durationMs - currentPositionMs) + "ms remaining. Queueing advance.");
                                 queueAdvancePending = true;

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -61,7 +61,7 @@ public class PlaybackManager {
 
     // Track Listening
     private boolean isTrackingListen = false;
-    private final long LISTEN_THRESHOLD_MS = 10000; // 10 seconds
+    private final long LISTEN_THRESHOLD_MS = 10000; // fallback when duration unknown
     private String currentListenTrackId = null;
     private boolean hasRecordedListen = false;
     private boolean isDeviceWarningActive = false;
@@ -268,6 +268,11 @@ public class PlaybackManager {
                 }
             }
 
+            // Set duration before listen tracking starts: the listen threshold
+            // is a third of the track duration, so it must reflect the new track.
+            currentPositionMs = playerState.playbackPosition;
+            durationMs = remoteTrack.duration;
+
             handleListenTracking(currentSong.getId(), !playerState.isPaused);
 
             // Update playing state
@@ -278,9 +283,6 @@ public class PlaybackManager {
             if (wasPlaying != isPlaying || trackChanged) {
                 notifyPlaybackStateChanged();
             }
-
-            currentPositionMs = playerState.playbackPosition;
-            durationMs = remoteTrack.duration;
 
             // Always notify position change when getting player state
             notifyPlaybackPositionChanged();
@@ -608,7 +610,11 @@ public class PlaybackManager {
                 }
             };
 
-            listenHandler.postDelayed(listenRunnable, LISTEN_THRESHOLD_MS);
+            // Register a listen once a third of the song has played. This scales
+            // with the track and avoids counting accidental skim-throughs. Fall
+            // back to a fixed threshold when the duration isn't known yet.
+            long thresholdMs = durationMs > 0 ? durationMs / 3 : LISTEN_THRESHOLD_MS;
+            listenHandler.postDelayed(listenRunnable, thresholdMs);
         }
     }
 

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -81,6 +81,7 @@ public class PlaybackManager {
     private List<SongModel> secondaryQueue = new ArrayList<>();
     private int secondaryIndex = -1;
     private final List<SongModel> history = new ArrayList<>();
+    private static final int MAX_HISTORY = 200;
     // Guard: only fire advanceQueue() once per song-end
     private boolean queueAdvancePending = false;
     // Timestamp of last advance — suppress end-of-song check for 3s after an advance
@@ -602,6 +603,10 @@ public class PlaybackManager {
             return;
         }
         history.add(song);
+        // Cap the stack so a long session can't grow it without bound.
+        if (history.size() > MAX_HISTORY) {
+            history.remove(0);
+        }
     }
 
     public List<SongModel> getHistory() {

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -406,6 +406,63 @@ public class PlaybackManager {
         queueAdvancePending = false;
     }
 
+    // Append a song to the end of the queue. If no queue is active, seed one
+    // anchored at the currently-playing song (or the new song if nothing plays).
+    // No-op if the song is already upcoming in the queue.
+    public boolean addToQueue(SongModel song) {
+        if (song == null) return false;
+        if (isInQueue(song)) return false;
+
+        if (queue.isEmpty()) {
+            queue = new ArrayList<>();
+            if (currentSong != null && !currentSong.getUri().equals(song.getUri())) {
+                queue.add(currentSong);
+                queueIndex = 0;
+            } else {
+                queueIndex = -1;
+            }
+            queue.add(song);
+        } else {
+            queue.add(song);
+        }
+        Log.i(TAG, "addToQueue: '" + song.getName() + "' (queue size " + queue.size() + ")");
+        return true;
+    }
+
+    // Remove a song from the queue by URI. The currently-playing song cannot be
+    // removed. queueIndex is shifted to keep pointing at the current song.
+    public boolean removeFromQueue(SongModel song) {
+        if (song == null || queue.isEmpty()) return false;
+        if (currentSong != null && currentSong.getUri().equals(song.getUri())) return false;
+
+        for (int i = 0; i < queue.size(); i++) {
+            if (queue.get(i).getUri().equals(song.getUri())) {
+                queue.remove(i);
+                if (i < queueIndex) queueIndex--;
+                if (queue.isEmpty()) {
+                    queueIndex = -1;
+                    queueAdvancePending = false;
+                }
+                Log.i(TAG, "removeFromQueue: '" + song.getName() + "' (queue size " + queue.size() + ")");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // True when the song is upcoming in the queue (at or after the current
+    // position). The currently-playing song is not considered "in queue" for
+    // the purposes of the swipe-to-remove affordance.
+    public boolean isInQueue(SongModel song) {
+        if (song == null || queue.isEmpty() || queueIndex < 0) return false;
+        for (int i = queueIndex; i < queue.size(); i++) {
+            if (queue.get(i).getUri().equals(song.getUri())) {
+                return !(currentSong != null && currentSong.getUri().equals(song.getUri()));
+            }
+        }
+        return false;
+    }
+
     public boolean hasActiveQueue() {
         return !queue.isEmpty();
     }

--- a/app/src/main/res/drawable/ic_queue_add.xml
+++ b/app/src/main/res/drawable/ic_queue_add.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/white">
+    <!-- Queue lines -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,7h12v2H3z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,11h12v2H3z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,15h8v2H3z" />
+    <!-- Plus badge (top-right) -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,7h2v3h3v2h-3v3h-2v-3h-3v-2h3z" />
+</vector>

--- a/app/src/main/res/drawable/ic_queue_remove.xml
+++ b/app/src/main/res/drawable/ic_queue_remove.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/white">
+    <!-- Queue lines -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,7h12v2H3z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,11h12v2H3z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,15h8v2H3z" />
+    <!-- Minus badge (top-right) -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,10h8v2h-8z" />
+</vector>

--- a/app/src/main/res/drawable/queue_left_edge.xml
+++ b/app/src/main/res/drawable/queue_left_edge.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Plain lime vertical bar. The host cover container clips it to the cover's
+     rounded outline, so the top and bottom are cut by the corner curve. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/limeGreen" />
+</shape>

--- a/app/src/main/res/layout/song_recycler_view_row.xml
+++ b/app/src/main/res/layout/song_recycler_view_row.xml
@@ -26,19 +26,62 @@
             android:paddingTop="3dp"
             android:paddingBottom="3dp">
 
-            <com.google.android.material.imageview.ShapeableImageView
-                android:id="@+id/albumCoverView"
+            <FrameLayout
+                android:id="@+id/albumCoverContainer"
                 android:layout_width="70dp"
                 android:layout_height="70dp"
-                android:contentDescription="@string/songAlbumCoverImage"
-                android:padding="5dp"
-                android:background="?attr/selectableItemBackground"
-                android:longClickable="true"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:shapeAppearanceOverlay="@style/roundedImageView"
-                tools:srcCompat="@tools:sample/avatars" />
+                app:layout_constraintTop_toTopOf="parent">
+
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:id="@+id/albumCoverView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@string/songAlbumCoverImage"
+                    android:padding="5dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:longClickable="true"
+                    app:shapeAppearanceOverlay="@style/roundedImageView"
+                    tools:srcCompat="@tools:sample/avatars" />
+
+                <!-- Sized to the album art and clipped to its rounded outline
+                     in code, so anything inside is cut by the cover's corners. -->
+                <FrameLayout
+                    android:id="@+id/coverClip"
+                    android:layout_width="60dp"
+                    android:layout_height="60dp"
+                    android:layout_gravity="center">
+
+                    <!-- Plain vertical lime bar on the cover's left edge; the
+                         clip cuts its top and bottom along the corner curve. -->
+                    <View
+                        android:id="@+id/queuedEdge"
+                        android:layout_width="3dp"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="start"
+                        android:background="@drawable/queue_left_edge"
+                        android:visibility="gone" />
+
+                    <!-- Wipe-in overlay + icon shown while swiping the cover. -->
+                    <View
+                        android:id="@+id/queueSwipeOverlay"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:background="@color/limeGreen"
+                        android:visibility="gone" />
+
+                    <ImageView
+                        android:id="@+id/queueSwipeIcon"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:layout_gravity="center"
+                        android:visibility="gone"
+                        tools:src="@drawable/ic_queue_add" />
+
+                </FrameLayout>
+
+            </FrameLayout>
 
             <LinearLayout
                 android:id="@+id/textColumn"
@@ -48,10 +91,10 @@
                 android:layout_marginEnd="34dp"
                 android:gravity="center_vertical"
                 android:orientation="vertical"
-                app:layout_constraintBottom_toBottomOf="@+id/albumCoverView"
+                app:layout_constraintBottom_toBottomOf="@+id/albumCoverContainer"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/albumCoverView"
-                app:layout_constraintTop_toTopOf="@+id/albumCoverView">
+                app:layout_constraintStart_toEndOf="@+id/albumCoverContainer"
+                app:layout_constraintTop_toTopOf="@+id/albumCoverContainer">
 
                 <TextView
                     android:id="@+id/songNameView"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,6 +15,9 @@
     <color name="faintTanAccent">#80E3CDB3</color>
     <color name="purpleTheme">#4C00B7</color>
     <color name="shimmer_placeholder">#6F6F6F</color>
+    <color name="limeGreen">#32CD32</color>
+    <color name="queueAddGreen">#2E7D32</color>
+    <color name="queueRemoveRed">#C62828</color>
     <color name="playback_bar_base">#00012E</color>
     <!-- Splash gradient: dark blue (bottom-left) -> lighter blue/green (top-right) -->
     <color name="splash_gradient_start">#00116A</color>


### PR DESCRIPTION
## Overview

Adds Spotify-style queue management to playlists, plus two related playback fixes.

## Changes

### Swipe-to-queue
- Swipe right on a playlist song row to add it to the queue (or remove it if already queued); animated green/red overlay tracks the swipe.
- Lime-green left edge on the album cover marks queued (upcoming) songs.
- Swiping the currently-playing song is blocked — it can't be queued or removed while playing.

### Spotify-style split queue (`PlaybackManager`)
- **Primary queue** — explicit swipe-adds, FIFO, played before the playlist flow and consumed once played.
- **Secondary queue** — the playlist flow seeded by tapping a song; its anchor only advances when a playlist song plays, so primary adds slot in *between* playlist tracks and the playlist resumes after them.
- **History** — every played song is pushed to a history stack (plumbing for a future previous-song control; no UI yet).
- Explicit adds survive switching playlists; `removeFromQueue` works for both queues.

### Playback fixes
- Lime queued-edge now clears as soon as a queued song starts playing (rebinds rows on track change).
- A listen is registered at **a third of the track's duration** instead of a fixed ~10s — more realistic and skip-resistant.

### Misc
- Manage-sheet playlists ordered: current first, then favourites.

## Testing
Built and installed on device (SM-G998B, Android 15); queue ordering, swipe add/remove, and lime-edge behavior exercised manually.
