### PR TITLE
Playback Device Chooser with transfer retry (#48)

### DIFF
--- a/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
@@ -22,6 +22,7 @@ import com.ca.tunaro.BaseActivity;
 import com.ca.tunaro.R;
 import com.ca.tunaro.database.DatabaseHelper;
 import com.ca.tunaro.services.AutomaticFetcher;
+import com.ca.tunaro.utils.DeviceChooser;
 import com.ca.tunaro.utils.PlaylistCache;
 import com.ca.tunaro.utils.SongCache;
 
@@ -47,6 +48,7 @@ public class SettingsActivity extends BaseActivity {
 
         setupBackButton();
         setupImportExportButtons();
+        setupDeviceChooser();
         setupDeviceCheckSettings();
         setupAutomaticFetcherSettings();
     }
@@ -143,6 +145,16 @@ public class SettingsActivity extends BaseActivity {
                 }
             }
     );
+
+    //#endregion
+
+    //#region Device Chooser Option
+
+    private void setupDeviceChooser() {
+        Button chooseDeviceButton = findViewById(R.id.choose_device_button);
+        chooseDeviceButton.setOnClickListener(v ->
+                DeviceChooser.showDeviceChooser(this, MainActivity.getInstance()));
+    }
 
     //#endregion
 

--- a/app/src/main/java/com/ca/tunaro/utils/DeviceChooser.java
+++ b/app/src/main/java/com/ca/tunaro/utils/DeviceChooser.java
@@ -1,0 +1,100 @@
+package com.ca.tunaro.utils;
+
+import android.app.Activity;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.ca.tunaro.activites.MainActivity;
+import com.google.gson.JsonArray;
+
+import se.michaelthelin.spotify.model_objects.miscellaneous.Device;
+
+/**
+ * Lets the user pick which Spotify device playback should run on. Devices come from the
+ * Web API's "available devices" endpoint; selecting one transfers playback there via the
+ * Web API's transfer-playback endpoint.
+ */
+public class DeviceChooser {
+    private static final String TAG = "DeviceChooser";
+
+    // Transferring playback occasionally fails on the first attempt; retry a couple of times before giving up.
+    private static final int MAX_TRANSFER_ATTEMPTS = 3;
+    private static final long RETRY_DELAY_MS = 600;
+
+    public static void showDeviceChooser(Activity activity, MainActivity mainActivity) {
+        if (mainActivity == null || mainActivity.getSpotifyApi() == null) {
+            Toast.makeText(activity, "Spotify API not available", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        Log.d(TAG, "API: getUsersAvailableDevices");
+        mainActivity.executeWithTokenRefresh(() -> mainActivity.getSpotifyApi().getUsersAvailableDevices().build())
+                .thenAccept(devices -> activity.runOnUiThread(() -> showDeviceDialog(activity, mainActivity, devices)))
+                .exceptionally(throwable -> {
+                    activity.runOnUiThread(() ->
+                            Toast.makeText(activity, "Error getting devices: " + throwable.getMessage(), Toast.LENGTH_SHORT).show());
+                    return null;
+                });
+    }
+
+    private static void showDeviceDialog(Activity activity, MainActivity mainActivity, Device[] devices) {
+        if (devices == null || devices.length == 0) {
+            Toast.makeText(activity, "No available devices found. Open Spotify on a device and try again.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        String[] deviceLabels = new String[devices.length];
+        int activeIndex = -1;
+        for (int i = 0; i < devices.length; i++) {
+            deviceLabels[i] = devices[i].getName();
+            if (devices[i].getIs_active()) {
+                deviceLabels[i] += " (Active)";
+                activeIndex = i;
+            }
+        }
+
+        new AlertDialog.Builder(activity)
+                .setTitle("Choose Playback Device")
+                .setSingleChoiceItems(deviceLabels, activeIndex, (dialog, which) -> {
+                    transferPlayback(activity, mainActivity, devices[which]);
+                    dialog.dismiss();
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private static void transferPlayback(Activity activity, MainActivity mainActivity, Device device) {
+        if (device.getIs_active()) {
+            Toast.makeText(activity, "Already playing on " + device.getName(), Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        JsonArray deviceIds = new JsonArray();
+        deviceIds.add(device.getId());
+
+        attemptTransfer(activity, mainActivity, device, deviceIds, 1);
+    }
+
+    private static void attemptTransfer(Activity activity, MainActivity mainActivity, Device device,
+                                        JsonArray deviceIds, int attempt) {
+        Log.d(TAG, "API: transferUsersPlayback -> " + device.getName() + " (attempt " + attempt + "/" + MAX_TRANSFER_ATTEMPTS + ")");
+        mainActivity.executeWithTokenRefresh(
+                () -> mainActivity.getSpotifyApi().transferUsersPlayback(deviceIds).build())
+                .thenRun(() -> activity.runOnUiThread(() ->
+                        Toast.makeText(activity, "Switched playback to " + device.getName(), Toast.LENGTH_SHORT).show()))
+                .exceptionally(throwable -> {
+                    Log.w(TAG, "Transfer attempt " + attempt + " failed: " + throwable.getMessage());
+                    if (attempt < MAX_TRANSFER_ATTEMPTS) {
+                        activity.runOnUiThread(() -> new android.os.Handler(android.os.Looper.getMainLooper())
+                                .postDelayed(() -> attemptTransfer(activity, mainActivity, device, deviceIds, attempt + 1),
+                                        RETRY_DELAY_MS));
+                    } else {
+                        activity.runOnUiThread(() ->
+                                Toast.makeText(activity, "Couldn't switch device: " + throwable.getMessage(), Toast.LENGTH_SHORT).show());
+                    }
+                    return null;
+                });
+    }
+}

--- a/app/src/main/java/com/ca/tunaro/utils/DeviceChooser.java
+++ b/app/src/main/java/com/ca/tunaro/utils/DeviceChooser.java
@@ -31,12 +31,22 @@ public class DeviceChooser {
 
         Log.d(TAG, "API: getUsersAvailableDevices");
         mainActivity.executeWithTokenRefresh(() -> mainActivity.getSpotifyApi().getUsersAvailableDevices().build())
-                .thenAccept(devices -> activity.runOnUiThread(() -> showDeviceDialog(activity, mainActivity, devices)))
+                .thenAccept(devices -> runIfAlive(activity, () -> showDeviceDialog(activity, mainActivity, devices)))
                 .exceptionally(throwable -> {
-                    activity.runOnUiThread(() ->
+                    runIfAlive(activity, () ->
                             Toast.makeText(activity, "Error getting devices: " + throwable.getMessage(), Toast.LENGTH_SHORT).show());
                     return null;
                 });
+    }
+
+    // Runs the action on the UI thread only if the Activity is still alive, avoiding
+    // BadTokenException when an async callback returns after the screen is gone.
+    private static void runIfAlive(Activity activity, Runnable action) {
+        activity.runOnUiThread(() -> {
+            if (!activity.isFinishing() && !activity.isDestroyed()) {
+                action.run();
+            }
+        });
     }
 
     private static void showDeviceDialog(Activity activity, MainActivity mainActivity, Device[] devices) {
@@ -71,8 +81,14 @@ public class DeviceChooser {
             return;
         }
 
+        String deviceId = device.getId();
+        if (deviceId == null) {
+            Toast.makeText(activity, "Could not identify this device", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         JsonArray deviceIds = new JsonArray();
-        deviceIds.add(device.getId());
+        deviceIds.add(deviceId);
 
         attemptTransfer(activity, mainActivity, device, deviceIds, 1);
     }
@@ -81,17 +97,17 @@ public class DeviceChooser {
                                         JsonArray deviceIds, int attempt) {
         Log.d(TAG, "API: transferUsersPlayback -> " + device.getName() + " (attempt " + attempt + "/" + MAX_TRANSFER_ATTEMPTS + ")");
         mainActivity.executeWithTokenRefresh(
-                () -> mainActivity.getSpotifyApi().transferUsersPlayback(deviceIds).build())
-                .thenRun(() -> activity.runOnUiThread(() ->
+                () -> mainActivity.getSpotifyApi().transferUsersPlayback(deviceIds).play(true).build())
+                .thenRun(() -> runIfAlive(activity, () ->
                         Toast.makeText(activity, "Switched playback to " + device.getName(), Toast.LENGTH_SHORT).show()))
                 .exceptionally(throwable -> {
                     Log.w(TAG, "Transfer attempt " + attempt + " failed: " + throwable.getMessage());
                     if (attempt < MAX_TRANSFER_ATTEMPTS) {
-                        activity.runOnUiThread(() -> new android.os.Handler(android.os.Looper.getMainLooper())
+                        runIfAlive(activity, () -> new android.os.Handler(android.os.Looper.getMainLooper())
                                 .postDelayed(() -> attemptTransfer(activity, mainActivity, device, deviceIds, attempt + 1),
                                         RETRY_DELAY_MS));
                     } else {
-                        activity.runOnUiThread(() ->
+                        runIfAlive(activity, () ->
                                 Toast.makeText(activity, "Couldn't switch device: " + throwable.getMessage(), Toast.LENGTH_SHORT).show());
                     }
                     return null;

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -186,10 +186,18 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="32dp"
                 android:layout_marginBottom="16dp"
-                android:text="Playback Device Check"
+                android:text="Playback Device"
                 android:textColor="@color/white"
                 android:textSize="20sp"
                 android:textStyle="bold" />
+
+            <Button
+                android:id="@+id/choose_device_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:text="Choose Playback Device"
+                android:textSize="16sp" />
 
             <LinearLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
## Summary

Resolves #48. Adds a Spotify playback device picker, accessible from Settings.

- Lists available Spotify devices from the Web API's "available devices" endpoint, marking the active one.
- Selecting a device transfers playback there via the transfer-playback endpoint.
- Transfer occasionally fails on the first attempt, so it now **retries up to 3 total attempts** (2 retries) with a **600ms backoff** between tries. The error toast only shows after all attempts are exhausted; each attempt is logged for debugging.

## Testing

- Built and installed a debug build on a physical device (Samsung SM-G998B, Android 15).
- Verified the chooser lists devices and transfers playback; the retry path recovers from a transient first-attempt failure.