### PR TITLE
Loop snippets: cycling end-behaviour with default setting (#45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ secrets.xml
 
 # Planning docs
 STATUS.md
+docs/
+CONTEXT.md

--- a/app/src/main/java/com/ca/tunaro/BaseActivity.java
+++ b/app/src/main/java/com/ca/tunaro/BaseActivity.java
@@ -195,6 +195,10 @@ public class BaseActivity extends AppCompatActivity implements PlaybackManager.P
             });
         }
         if (playbackSeekbar != null) {
+            // Block seeking while a snippet is playing: the snippet owns the
+            // playhead (its range + end-timer), so a manual drag would fight it.
+            playbackSeekbar.setOnTouchListener((v, e) ->
+                    playbackManager != null && playbackManager.isSnippetMode());
             playbackSeekbar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
                 @Override
                 public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {

--- a/app/src/main/java/com/ca/tunaro/BaseActivity.java
+++ b/app/src/main/java/com/ca/tunaro/BaseActivity.java
@@ -1,5 +1,6 @@
 package com.ca.tunaro;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
@@ -141,6 +142,9 @@ public class BaseActivity extends AppCompatActivity implements PlaybackManager.P
         setupPlaybackBar();
     }
 
+    // Seekbar touch is consumed (returns true, no performClick) to block seeking
+    // during snippet playback; the accessibility warning does not apply here.
+    @SuppressLint("ClickableViewAccessibility")
     private void setupPlaybackBar() {
         // Find playback bar views
         playbackBar = findViewById(R.id.playback_bar);

--- a/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/SettingsActivity.java
@@ -21,6 +21,7 @@ import androidx.appcompat.widget.SwitchCompat;
 import com.ca.tunaro.BaseActivity;
 import com.ca.tunaro.R;
 import com.ca.tunaro.database.DatabaseHelper;
+import com.ca.tunaro.managers.PlaybackManager;
 import com.ca.tunaro.services.AutomaticFetcher;
 import com.ca.tunaro.utils.PlaylistCache;
 import com.ca.tunaro.utils.SongCache;
@@ -47,6 +48,7 @@ public class SettingsActivity extends BaseActivity {
 
         setupBackButton();
         setupImportExportButtons();
+        setupSnippetPlaybackSettings();
         setupDeviceCheckSettings();
         setupAutomaticFetcherSettings();
     }
@@ -143,6 +145,41 @@ public class SettingsActivity extends BaseActivity {
                 }
             }
     );
+
+    //#endregion
+
+    //#region Snippet Playback Option
+
+    private void setupSnippetPlaybackSettings() {
+        android.widget.RadioGroup group = findViewById(R.id.snippet_default_mode_group);
+
+        // Reflect the saved default in the radio selection.
+        switch (PlaybackManager.getDefaultSnippetEndMode(this)) {
+            case LOOP:
+                group.check(R.id.snippet_mode_loop);
+                break;
+            case DETACH:
+                group.check(R.id.snippet_mode_detach);
+                break;
+            case STOP:
+            default:
+                group.check(R.id.snippet_mode_stop);
+                break;
+        }
+
+        group.setOnCheckedChangeListener((g, checkedId) -> {
+            PlaybackManager.SnippetEndMode mode;
+            if (checkedId == R.id.snippet_mode_loop) {
+                mode = PlaybackManager.SnippetEndMode.LOOP;
+            } else if (checkedId == R.id.snippet_mode_detach) {
+                mode = PlaybackManager.SnippetEndMode.DETACH;
+            } else {
+                mode = PlaybackManager.SnippetEndMode.STOP;
+            }
+            prefs.edit().putString(
+                    PlaybackManager.PREF_SNIPPET_DEFAULT_MODE, mode.name()).apply();
+        });
+    }
 
     //#endregion
 

--- a/app/src/main/java/com/ca/tunaro/adapters/SongSnippetsAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/SongSnippetsAdapter.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.ca.tunaro.R;
+import com.ca.tunaro.managers.PlaybackManager;
 import com.ca.tunaro.models.SongSnippet;
 import com.ca.tunaro.utils.SnippetTheme;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -42,7 +43,6 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
     public interface OnSnippetActionListener {
         void onPlaySnippet(SongSnippet snippet);
         void onPauseSnippet(SongSnippet snippet);
-        void onDetachSnippet(SongSnippet snippet);
         void onEditSnippet(SongSnippet snippet);
     }
 
@@ -101,11 +101,11 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
             }
         });
 
-        // Set up detach button click listener
-        holder.detachButton.setOnClickListener(v -> {
-            if (listener != null) {
-                listener.onDetachSnippet(snippet);
-            }
+        // Mode button: cycles the end-behaviour of the currently-playing snippet
+        // (Stop → Loop → Detach → Stop) and reflects the new mode immediately.
+        holder.modeButton.setOnClickListener(v -> {
+            PlaybackManager.getInstance().cycleSnippetEndMode();
+            bindModeButton(holder, snippet);
         });
 
         // Set up long click for editing
@@ -154,6 +154,8 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
         holder.snippetPlayButton.setImageResource(
                 active ? R.drawable.stop_circle_filled : R.drawable.play_circle_filled);
 
+        bindModeButton(holder, snippet);
+
         if (!isThisSong || playbackPositionMs < 0) {
             // Not the playing song: leave whatever position the bar holds.
             cancelAnimator(holder);
@@ -180,6 +182,59 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
         cancelAnimator(holder);
         int target = (int) Math.min(max, playbackPositionMs - start);
         bar.setProgress(target);
+    }
+
+    /**
+     * Drive the mode button. Two cases show it:
+     *   - the snippet currently playing/paused: glyph reflects the live end-mode;
+     *   - a natural passthrough — a normal song playing through this snippet's
+     *     range (not snippet playback): show the continue/passthrough glyph,
+     *     since that is exactly what is happening.
+     * Otherwise it is hidden. At most one row shows it.
+     */
+    private void bindModeButton(SnippetViewHolder holder, SongSnippet snippet) {
+        PlaybackManager pm = PlaybackManager.getInstance();
+        SongSnippet current = pm.getCurrentSnippet();
+        boolean isCurrentRow = pm.isSnippetPlaying() && current != null && current == snippet;
+
+        int glyph;
+        if (isCurrentRow) {
+            switch (pm.getSnippetEndMode()) {
+                case LOOP:
+                    glyph = R.drawable.snippet_mode_loop;
+                    break;
+                case DETACH:
+                    glyph = R.drawable.snippet_mode_detach;
+                    break;
+                case STOP:
+                default:
+                    glyph = R.drawable.snippet_mode_stop;
+                    break;
+            }
+        } else if (isNaturalPassthrough(snippet)) {
+            glyph = R.drawable.snippet_mode_detach;
+        } else {
+            holder.modeButton.setVisibility(View.GONE);
+            return;
+        }
+
+        holder.modeButton.setVisibility(View.VISIBLE);
+        holder.modeButton.setImageResource(glyph);
+        // The glyph itself distinguishes the mode; keep it a constant white so
+        // the mode isn't also signalled by colour.
+        holder.modeButton.setColorFilter(android.graphics.Color.WHITE);
+    }
+
+    // True when a normal (non-snippet) playhead is currently inside this
+    // snippet's range — the song is naturally passing through the snippet.
+    private boolean isNaturalPassthrough(SongSnippet snippet) {
+        if (PlaybackManager.getInstance().isSnippetMode()) return false;
+        boolean isThisSong = playingSongId != null
+                && (playingSongId.equals(snippet.getSongId())
+                    || (variantUris != null && variantUris.contains(playingSongId)));
+        return isThisSong && isPlaying
+                && playbackPositionMs >= snippet.getStartTime()
+                && playbackPositionMs <= snippet.getEndTime();
     }
 
     private void cancelAnimator(SnippetViewHolder holder) {
@@ -221,8 +276,7 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
         holder.snippetSeekBar.setProgressBackgroundTintList(android.content.res.ColorStateList.valueOf(theme.seekbarTrack));
         holder.snippetSeekBar.setThumbTintList(android.content.res.ColorStateList.valueOf(theme.seekbarThumb));
 
-        // Icons + play button.
-        holder.detachButton.setColorFilter(theme.icon);
+        // Mode button tint is set per-mode in bindModeButton; play button below.
         holder.snippetPlayButton.setBackgroundTintList(android.content.res.ColorStateList.valueOf(theme.playButton));
         // Play/stop glyph: black or white depending on the play button's brightness.
         holder.snippetPlayButton.setImageTintList(android.content.res.ColorStateList.valueOf(theme.playButtonIcon));
@@ -283,7 +337,7 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
         TextView snippetTimeRange;
         SeekBar snippetSeekBar;
         FloatingActionButton snippetPlayButton;
-        ImageButton detachButton;
+        ImageButton modeButton;
         ValueAnimator seekAnimator;
         boolean active;
 
@@ -295,7 +349,7 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
             snippetTimeRange = itemView.findViewById(R.id.snippetTimeRange);
             snippetSeekBar = itemView.findViewById(R.id.snippetSeekBar);
             snippetPlayButton = itemView.findViewById(R.id.snippetPlayButton);
-            detachButton = itemView.findViewById(R.id.detachButton);
+            modeButton = itemView.findViewById(R.id.modeButton);
         }
     }
 }

--- a/app/src/main/java/com/ca/tunaro/adapters/SongSnippetsAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/SongSnippetsAdapter.java
@@ -195,7 +195,11 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
     private void bindModeButton(SnippetViewHolder holder, SongSnippet snippet) {
         PlaybackManager pm = PlaybackManager.getInstance();
         SongSnippet current = pm.getCurrentSnippet();
-        boolean isCurrentRow = pm.isSnippetPlaying() && current != null && current == snippet;
+        // Match on uuid rather than object reference: a snippet can be re-fetched
+        // into a fresh instance between the play call and this bind, and every
+        // snippet (including unsaved/preview ones) carries a stable uuid.
+        boolean isCurrentRow = pm.isSnippetPlaying() && current != null
+                && current.getUuid() != null && current.getUuid().equals(snippet.getUuid());
 
         int glyph;
         if (isCurrentRow) {
@@ -218,6 +222,9 @@ public class SongSnippetsAdapter extends RecyclerView.Adapter<SongSnippetsAdapte
             return;
         }
 
+        // Only the active row's button cycles the mode; a passthrough glyph is
+        // purely informational, so it stays visible but non-interactive.
+        holder.modeButton.setEnabled(isCurrentRow);
         holder.modeButton.setVisibility(View.VISIBLE);
         holder.modeButton.setImageResource(glyph);
         // The glyph itself distinguishes the mode; keep it a constant white so

--- a/app/src/main/java/com/ca/tunaro/fragments/SongSnippetsFragment.java
+++ b/app/src/main/java/com/ca/tunaro/fragments/SongSnippetsFragment.java
@@ -261,12 +261,6 @@ public class SongSnippetsFragment extends Fragment implements PlaybackManager.Pl
             }
 
             @Override
-            public void onDetachSnippet(SongSnippet snippet) {
-                // Detach logic
-                detachSnippet();
-            }
-
-            @Override
             public void onEditSnippet(SongSnippet snippet) {
                 // Edit logic
                 showEditSnippetDialog(snippet);
@@ -283,10 +277,6 @@ public class SongSnippetsFragment extends Fragment implements PlaybackManager.Pl
 
     private void playSnippet(SongSnippet snippet) {
         PlaybackManager.getInstance().playSnippet(snippet);
-    }
-
-    private void detachSnippet() {
-        PlaybackManager.getInstance().detachSnippet();
     }
 
     private void showSnippetCreationOverlay() {

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -89,12 +89,25 @@ public class PlaybackManager {
     private long lastAdvanceTimeMs = 0;
 
     //#region Snippet Playback Fields
+    // The behaviour applied when a snippet's end-timer fires. Transient: held in
+    // memory for the live session only, never persisted. See ADR 0001.
+    public enum SnippetEndMode { STOP, LOOP, DETACH }
+
+    // The persisted default mode a snippet starts in (set in SettingsActivity).
+    public static final String PREFS_NAME = "TunaroPrefs";
+    public static final String PREF_SNIPPET_DEFAULT_MODE = "snippet_default_end_mode";
+
     private boolean isSnippetMode = false;
     private boolean isSnippetPlaying = false;
     private SongSnippet currentSnippet;
+    private SnippetEndMode snippetEndMode = SnippetEndMode.STOP;
     private final Handler snippetHandler = new Handler(Looper.getMainLooper());
     private Runnable snippetEndRunnable;
     private int activeSnippetTimers = 0;
+    // Wall-clock bookkeeping so the end-timer can be paused with the song and
+    // resumed from the time that was left, instead of firing while paused.
+    private long snippetTimerDueAtMs = 0;   // when the pending timer would fire
+    private long snippetTimerRemainingMs = 0; // time left while paused; 0 = running
     //#endregion
 
     // Listeners
@@ -357,6 +370,11 @@ public class PlaybackManager {
 
     public void playSong(SongModel song) {
         if (spotifyAppRemote != null && isConnected) {
+            // Starting a normal song leaves any active snippet: tear down snippet
+            // state so listen-tracking, auto-advance and seekbar seeking all resume.
+            if (isSnippetPlaying || isSnippetMode) {
+                stopSnippetPlayback();
+            }
             spotifyAppRemote.getPlayerApi().play(song.getUri())
                     .setResultCallback(empty -> {
                         currentSong = song;
@@ -507,6 +525,11 @@ public class PlaybackManager {
         if (spotifyAppRemote != null && isConnected) {
             checkPlaybackDevice();
             if (isPlaying) {
+                // Pausing mid-snippet holds the end-timer so it can't fire while
+                // the song is paused; resuming continues from the time that was left.
+                if (isSnippetMode) {
+                    holdSnippetEndTimer();
+                }
                 spotifyAppRemote.getPlayerApi().pause()
                         .setResultCallback(empty -> {
                             isPlaying = false;
@@ -516,6 +539,9 @@ public class PlaybackManager {
                 spotifyAppRemote.getPlayerApi().resume()
                         .setResultCallback(empty -> {
                             isPlaying = true;
+                            if (isSnippetMode) {
+                                resumeSnippetEndTimer();
+                            }
                             notifyPlaybackStateChanged();
                         });
             }
@@ -734,6 +760,13 @@ public class PlaybackManager {
         // Cancel any existing snippet timer
         cancelCurrentSnippetTimer();
 
+        // Starting a (different) snippet resets the end-mode to the user's
+        // configured default. Replaying the same snippet — e.g. resuming after a
+        // pause — preserves the mode the user had selected.
+        if (currentSnippet == null || snippet != currentSnippet) {
+            snippetEndMode = getDefaultSnippetEndMode(applicationContext);
+        }
+
         isSnippetPlaying = true;
         currentSnippet = snippet;
         setSnippetMode(true);
@@ -782,20 +815,77 @@ public class PlaybackManager {
 
     private void startSnippetEndTimer(long duration) {
         activeSnippetTimers++;
+        snippetTimerRemainingMs = 0;
+        snippetTimerDueAtMs = System.currentTimeMillis() + duration;
 
         snippetEndRunnable = () -> {
             activeSnippetTimers--;
 
             if (activeSnippetTimers <= 0) {
                 activeSnippetTimers = 0;
-                if (spotifyAppRemote != null && spotifyAppRemote.isConnected()) {
-                    spotifyAppRemote.getPlayerApi().pause();
-                }
-                stopSnippetPlayback();
+                handleSnippetEnd();
             }
         };
 
         snippetHandler.postDelayed(snippetEndRunnable, duration);
+    }
+
+    // Hold the end-timer while the song is paused mid-snippet: cancel the pending
+    // callback and remember how much of the snippet was left so resuming can pick
+    // up from there rather than restarting or firing during the pause.
+    private void holdSnippetEndTimer() {
+        if (snippetEndRunnable == null || snippetTimerRemainingMs > 0) {
+            return; // nothing pending, or already held
+        }
+        snippetTimerRemainingMs = Math.max(0, snippetTimerDueAtMs - System.currentTimeMillis());
+        snippetHandler.removeCallbacks(snippetEndRunnable);
+        snippetEndRunnable = null;
+        activeSnippetTimers = Math.max(0, activeSnippetTimers - 1);
+    }
+
+    // Re-arm the held end-timer for the remaining slice of the snippet.
+    private void resumeSnippetEndTimer() {
+        if (snippetTimerRemainingMs <= 0) {
+            return; // not held
+        }
+        long remaining = snippetTimerRemainingMs;
+        snippetTimerRemainingMs = 0;
+        startSnippetEndTimer(remaining);
+    }
+
+    // Evaluate the end-behaviour when the snippet's end-timer fires. The mode is
+    // the single source of truth, read here at fire-time (ADR 0001).
+    private void handleSnippetEnd() {
+        SongSnippet snippet = currentSnippet;
+
+        switch (snippetEndMode) {
+            case LOOP:
+                // Seek back to the snippet start and re-arm a fresh timer.
+                // Playback is already running, so seeking keeps it playing.
+                if (snippet != null && spotifyAppRemote != null && spotifyAppRemote.isConnected()) {
+                    long start = snippet.getStartTime();
+                    spotifyAppRemote.getPlayerApi().seekTo(start)
+                            .setResultCallback(seekResult ->
+                                    startSnippetEndTimer(snippet.getEndTime() - start));
+                }
+                break;
+
+            case DETACH:
+                // Let playback continue into the rest of the song. Clearing
+                // snippet mode resumes listen-tracking and queue auto-advance.
+                isSnippetPlaying = false;
+                currentSnippet = null;
+                setSnippetMode(false);
+                break;
+
+            case STOP:
+            default:
+                if (spotifyAppRemote != null && spotifyAppRemote.isConnected()) {
+                    spotifyAppRemote.getPlayerApi().pause();
+                }
+                stopSnippetPlayback();
+                break;
+        }
     }
 
     private void cancelCurrentSnippetTimer() {
@@ -804,6 +894,8 @@ public class PlaybackManager {
             snippetEndRunnable = null;
         }
         activeSnippetTimers = 0;
+        snippetTimerRemainingMs = 0;
+        snippetTimerDueAtMs = 0;
     }
 
     public void stopSnippetPlayback() {
@@ -813,10 +905,45 @@ public class PlaybackManager {
         cancelCurrentSnippetTimer();
     }
 
-    public void detachSnippet() {
-        setSnippetMode(false);
-        cancelCurrentSnippetTimer();
-        showToast("Playback will continue after snippet end");
+    /**
+     * Set the end-behaviour for the snippet currently playing/paused. The timer
+     * is NOT cancelled — the mode is just a flag read when the end-timer fires
+     * (ADR 0001), so switching modes mid-play stays coherent.
+     */
+    public void setSnippetEndMode(SnippetEndMode mode) {
+        if (mode != null) {
+            snippetEndMode = mode;
+        }
+    }
+
+    public SnippetEndMode getSnippetEndMode() {
+        return snippetEndMode;
+    }
+
+    /**
+     * The user's configured default end-mode for a freshly-started snippet,
+     * from TunaroPrefs. Falls back to STOP when unset or unrecognised.
+     */
+    public static SnippetEndMode getDefaultSnippetEndMode(Context context) {
+        if (context == null) return SnippetEndMode.STOP;
+        String name = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getString(PREF_SNIPPET_DEFAULT_MODE, SnippetEndMode.STOP.name());
+        try {
+            return SnippetEndMode.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return SnippetEndMode.STOP;
+        }
+    }
+
+    /** Advance the end-mode one step: STOP → LOOP → DETACH → STOP. */
+    public SnippetEndMode cycleSnippetEndMode() {
+        switch (snippetEndMode) {
+            case STOP:   snippetEndMode = SnippetEndMode.LOOP;   break;
+            case LOOP:   snippetEndMode = SnippetEndMode.DETACH; break;
+            case DETACH:
+            default:     snippetEndMode = SnippetEndMode.STOP;   break;
+        }
+        return snippetEndMode;
     }
 
     /**

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -525,14 +525,15 @@ public class PlaybackManager {
         if (spotifyAppRemote != null && isConnected) {
             checkPlaybackDevice();
             if (isPlaying) {
-                // Pausing mid-snippet holds the end-timer so it can't fire while
-                // the song is paused; resuming continues from the time that was left.
-                if (isSnippetMode) {
-                    holdSnippetEndTimer();
-                }
                 spotifyAppRemote.getPlayerApi().pause()
                         .setResultCallback(empty -> {
                             isPlaying = false;
+                            // Hold the end-timer once the pause has actually taken effect,
+                            // so it can't fire while paused; resuming continues from the
+                            // time that was left.
+                            if (isSnippetMode) {
+                                holdSnippetEndTimer();
+                            }
                             notifyPlaybackStateChanged();
                         });
             } else {
@@ -865,8 +866,13 @@ public class PlaybackManager {
                 if (snippet != null && spotifyAppRemote != null && spotifyAppRemote.isConnected()) {
                     long start = snippet.getStartTime();
                     spotifyAppRemote.getPlayerApi().seekTo(start)
-                            .setResultCallback(seekResult ->
-                                    startSnippetEndTimer(snippet.getEndTime() - start));
+                            .setResultCallback(seekResult -> {
+                                // Guard against a stale seek callback: the snippet may have
+                                // been stopped or swapped out while the seek was in flight.
+                                if (isSnippetMode && currentSnippet == snippet) {
+                                    startSnippetEndTimer(snippet.getEndTime() - start);
+                                }
+                            });
                 }
                 break;
 

--- a/app/src/main/res/drawable/snippet_mode_detach.xml
+++ b/app/src/main/res/drawable/snippet_mode_detach.xml
@@ -1,0 +1,43 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/white">
+    <!-- Continue-past-end: a vertical boundary line (the snippet end) with a
+         horizontal line through it and three chevrons marching rightward past
+         it, signalling "release the snippet boundary and play on". -->
+    <group>
+        <!-- vertical boundary line -->
+        <path
+            android:strokeColor="@android:color/white"
+            android:strokeWidth="1.6"
+            android:strokeLineCap="round"
+            android:pathData="M5,4 V20" />
+        <!-- horizontal line through it -->
+        <path
+            android:strokeColor="@android:color/white"
+            android:strokeWidth="1.6"
+            android:strokeLineCap="round"
+            android:pathData="M3,12 H20" />
+        <!-- marching chevrons -->
+        <path
+            android:strokeColor="@android:color/white"
+            android:strokeWidth="1.6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M9.5,9.5 L12,12 L9.5,14.5" />
+        <path
+            android:strokeColor="@android:color/white"
+            android:strokeWidth="1.6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M13.5,9.5 L16,12 L13.5,14.5" />
+        <path
+            android:strokeColor="@android:color/white"
+            android:strokeWidth="1.6"
+            android:strokeLineCap="round"
+            android:strokeLineJoin="round"
+            android:pathData="M17.5,9.5 L20,12 L17.5,14.5" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/snippet_mode_loop.xml
+++ b/app/src/main/res/drawable/snippet_mode_loop.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/white">
+    <!-- Standard Material "repeat" loop: tintable vector replacement for the
+         raster loop.png so the mode button can recolour cleanly. -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,7h10v3l4,-4 -4,-4v3L5,5v6h2L7,7zM17,17L7,17v-3l-4,4 4,4v-3h12v-6h-2v4z" />
+</vector>

--- a/app/src/main/res/drawable/snippet_mode_stop.xml
+++ b/app/src/main/res/drawable/snippet_mode_stop.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/white">
+    <!-- Play-to-end-and-halt: a play triangle with a vertical bar at its right
+         edge, signalling "play through to the end, then stop". -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,4l11,8 -11,8z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,4h3v16h-3z" />
+</vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -179,6 +179,63 @@
 
             <!--#endregion -->
 
+            <!--#region Snippet Playback Section -->
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:layout_marginBottom="8dp"
+                android:text="Snippet Playback"
+                android:textColor="@color/white"
+                android:textSize="20sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:text="What happens when a snippet reaches its end by default"
+                android:textColor="@color/white"
+                android:textSize="14sp" />
+
+            <RadioGroup
+                android:id="@+id/snippet_default_mode_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:orientation="vertical">
+
+                <RadioButton
+                    android:id="@+id/snippet_mode_stop"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:buttonTint="@color/white"
+                    android:text="Stop — pause at the snippet's end"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <RadioButton
+                    android:id="@+id/snippet_mode_loop"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:buttonTint="@color/white"
+                    android:text="Loop — replay the snippet range"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <RadioButton
+                    android:id="@+id/snippet_mode_detach"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:buttonTint="@color/white"
+                    android:text="Continue — play on into the rest of the song"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+            </RadioGroup>
+
+            <!--#endregion-->
+
             <!--#region Device Check Section -->
 
             <TextView

--- a/app/src/main/res/layout/snippet_item.xml
+++ b/app/src/main/res/layout/snippet_item.xml
@@ -83,17 +83,18 @@
                 tools:text="# 1" />
 
             <ImageButton
-                android:id="@+id/detachButton"
+                android:id="@+id/modeButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="20dp"
                 android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="Detach playback"
+                android:contentDescription="@string/cycle_snippet_end_mode"
                 android:padding="8dp"
                 android:scaleType="center"
                 android:scaleX="1.5"
                 android:scaleY="1.5"
-                android:src="@drawable/loop"
+                android:src="@drawable/snippet_mode_stop"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/snippetTitle" />
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="snippets_tab">Snippets</string>
     <string name="notes">Notes</string>
     <string name="toggle_snippet_playback">Toggle Snippet Playback</string>
+    <string name="cycle_snippet_end_mode">Cycle snippet end behaviour: stop, loop, continue</string>
 
     <string name="popularity_value">%d%%</string>
     <string name="more_details_url">https://songstats.com/</string>


### PR DESCRIPTION
Closes #45.

Adds **Loop** and **Detach** end-behaviours to snippets alongside the default **Stop**, exposed through a single cycling mode button and a persisted default-mode setting.

## Behaviour
Three mutually-exclusive end-behaviours, evaluated when the snippet end-timer fires (see ADR 0001):
- **Stop** (default) — pause at the snippet's end.
- **Loop** — seek back to the snippet start and re-arm the timer, playback continuing.
- **Detach** — clear snippet mode so listen-tracking and auto-advance resume, playing on into the rest of the song.

The mode is transient (in-memory, live session only) — no schema change.

## UI
- The snippet row's top-right button is now a single **mode button** that cycles Stop → Loop → Detach → Stop.
- Shown only on the currently playing/paused snippet; glyphs are constant white (the glyph shape signals the mode, not colour).
- When a normal song naturally plays through a snippet's range, that row shows the continue/passthrough glyph.
- New tintable vector glyphs for all three modes.

## Robustness
- The end-timer is held (not fired) while the song is paused mid-snippet, and resumes from the time left.
- Starting a normal song tears down snippet state so seeking, listen-tracking, and auto-advance all resume.
- The main playback-bar seekbar is locked while a snippet plays (the snippet owns the playhead).

## Settings
- New **Snippet Playback** section: a Stop/Loop/Continue radio group persisted to `TunaroPrefs`; a freshly-started snippet begins in the chosen default.