### PR TITLE
Rankings Activity: tournament-style ranking game (closes #2)

### DIFF
--- a/app/src/main/java/com/ca/tunaro/activites/RankingsActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/RankingsActivity.java
@@ -1,30 +1,249 @@
 package com.ca.tunaro.activites;
 
+import android.content.Intent;
 import android.os.Bundle;
-import android.widget.Button;
+import android.util.Log;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.cardview.widget.CardView;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
+import com.ca.tunaro.BaseActivity;
 import com.ca.tunaro.R;
+import com.ca.tunaro.adapters.RankingsLeaderboardAdapter;
+import com.ca.tunaro.database.DatabaseHelper;
+import com.ca.tunaro.interfaces.Library_RecyclerViewInterface;
+import com.ca.tunaro.models.SongModel;
+import com.ca.tunaro.models.SongSnippet;
+import com.ca.tunaro.utils.RankingsTournament;
+import com.ca.tunaro.utils.SelectedSongHolder;
+import com.google.android.material.button.MaterialButton;
 
-public class RankingsActivity extends AppCompatActivity {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RankingsActivity extends BaseActivity implements Library_RecyclerViewInterface {
+    private static final String TAG = "RankingsActivity";
+
+    // Offered bracket sizes; the pool size itself is always offered as "All"
+    private static final int[] BRACKET_SIZES = {4, 8, 16, 32, 64};
+    private static final int DEFAULT_BRACKET_SIZE = 16;
+
+    private DatabaseHelper dbHelper;
+    private RankingsTournament tournament;
+    private final List<SongModel> songPool = new ArrayList<>();
+    private final List<Integer> sizeOptions = new ArrayList<>();
+
+    // Phase containers
+    private View setupPhase, matchPhase, resultsPhase;
+
+    // Setup views
+    private TextView poolSummary, sizeLabel;
+    private Spinner sizeSpinner;
+    private MaterialButton startButton;
+
+    // Match views
+    private TextView roundTitle, matchProgress;
+    private CardView songCardA, songCardB;
+    private ImageView coverA, coverB;
+    private TextView songNameA, artistNameA, songNameB, artistNameB;
+
+    private RankingsLeaderboardAdapter leaderboardAdapter;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (checkForRecovery()) return;
+
         setContentView(R.layout.activity_rankings);
 
-        TextView placeholderText = findViewById(R.id.placeholder_text);
-        Button backButton = findViewById(R.id.back_button);
+        if (MainActivity.getInstance() == null) {
+            showToast("Could not connect to Spotify");
+            finish();
+            return;
+        }
 
-        placeholderText.setText("Rankings feature coming soon!");
+        dbHelper = new DatabaseHelper(this);
 
-        backButton.setOnClickListener(v -> finish());
+        setupPhase = findViewById(R.id.setup_phase);
+        matchPhase = findViewById(R.id.match_phase);
+        resultsPhase = findViewById(R.id.results_phase);
+
+        poolSummary = findViewById(R.id.pool_summary);
+        sizeLabel = findViewById(R.id.size_label);
+        sizeSpinner = findViewById(R.id.tournament_size_spinner);
+        startButton = findViewById(R.id.start_button);
+
+        roundTitle = findViewById(R.id.round_title);
+        matchProgress = findViewById(R.id.match_progress);
+        songCardA = findViewById(R.id.song_card_a);
+        songCardB = findViewById(R.id.song_card_b);
+        coverA = findViewById(R.id.cover_a);
+        coverB = findViewById(R.id.cover_b);
+        songNameA = findViewById(R.id.song_name_a);
+        artistNameA = findViewById(R.id.artist_name_a);
+        songNameB = findViewById(R.id.song_name_b);
+        artistNameB = findViewById(R.id.artist_name_b);
+
+        RecyclerView leaderboardRecyclerView = findViewById(R.id.leaderboard_recycler_view);
+        leaderboardAdapter = new RankingsLeaderboardAdapter(this, this);
+        leaderboardRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        leaderboardRecyclerView.setAdapter(leaderboardAdapter);
+
+        startButton.setOnClickListener(v -> startTournament());
+        songCardA.setOnClickListener(v -> chooseWinner(tournament.getContenderA()));
+        songCardB.setOnClickListener(v -> chooseWinner(tournament.getContenderB()));
+        findViewById(R.id.preview_button_a).setOnClickListener(v -> previewContender(tournament.getContenderA()));
+        findViewById(R.id.preview_button_b).setOnClickListener(v -> previewContender(tournament.getContenderB()));
+        findViewById(R.id.restart_button).setOnClickListener(v -> showSetupPhase());
+
+        loadSongPool();
+        showSetupPhase();
+    }
+
+    // The candidate pool is the library: every song with notes or snippets
+    private void loadSongPool() {
+        songPool.clear();
+        Set<String> songIds = new LinkedHashSet<>(dbHelper.getSongIdsWithNotes());
+        songIds.addAll(dbHelper.getSongIdsWithSnippets());
+
+        for (String songId : songIds) {
+            SongModel song = dbHelper.getLeanSong(songId);
+            if (song != null) songPool.add(song);
+        }
+        Log.d(TAG, "Loaded ranking pool of " + songPool.size() + " songs");
+    }
+
+    private void showSetupPhase() {
+        setupPhase.setVisibility(View.VISIBLE);
+        matchPhase.setVisibility(View.GONE);
+        resultsPhase.setVisibility(View.GONE);
+
+        if (songPool.size() < 2) {
+            poolSummary.setText("Add notes or snippets to at least two songs to play a ranking game");
+            sizeLabel.setVisibility(View.GONE);
+            sizeSpinner.setVisibility(View.GONE);
+            startButton.setVisibility(View.GONE);
+            return;
+        }
+
+        poolSummary.setText(songPool.size() + " songs in your library");
+
+        sizeOptions.clear();
+        List<String> labels = new ArrayList<>();
+        for (int size : BRACKET_SIZES) {
+            if (size < songPool.size()) {
+                sizeOptions.add(size);
+                labels.add(size + " random songs");
+            }
+        }
+        sizeOptions.add(songPool.size());
+        labels.add("All " + songPool.size() + " songs");
+
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, R.layout.item_spinner_dark, labels);
+        adapter.setDropDownViewResource(R.layout.item_spinner_dark);
+        sizeSpinner.setAdapter(adapter);
+
+        int defaultIndex = sizeOptions.indexOf(DEFAULT_BRACKET_SIZE);
+        sizeSpinner.setSelection(defaultIndex >= 0 ? defaultIndex : sizeOptions.size() - 1);
+    }
+
+    private void startTournament() {
+        int size = sizeOptions.get(sizeSpinner.getSelectedItemPosition());
+        List<SongModel> entrants = new ArrayList<>(songPool);
+        Collections.shuffle(entrants);
+        tournament = new RankingsTournament(new ArrayList<>(entrants.subList(0, size)));
+
+        setupPhase.setVisibility(View.GONE);
+        matchPhase.setVisibility(View.VISIBLE);
+        resultsPhase.setVisibility(View.GONE);
+
+        showCurrentMatch();
+    }
+
+    private void showCurrentMatch() {
+        if (tournament.isFinished()) {
+            showResults();
+            return;
+        }
+
+        roundTitle.setText(tournament.getRoundName());
+        matchProgress.setText("Match " + tournament.getMatchNumber() + " of " + tournament.getMatchesInRound());
+
+        bindContender(tournament.getContenderA(), coverA, songNameA, artistNameA);
+        bindContender(tournament.getContenderB(), coverB, songNameB, artistNameB);
+    }
+
+    private void bindContender(SongModel song, ImageView cover, TextView name, TextView artist) {
+        name.setText(song.getName());
+        artist.setText(song.getArtist());
+        Glide.with(this)
+                .load(song.getAlbumCoverUrl())
+                .placeholder(R.drawable.playlist_placeholder)
+                .error(R.drawable.playlist_placeholder)
+                .into(cover);
+    }
+
+    private void chooseWinner(SongModel winner) {
+        tournament.reportWinner(winner);
+        showCurrentMatch();
+    }
+
+    // Play the song's ranking snippet if one exists, otherwise the full song
+    private void previewContender(SongModel song) {
+        List<SongSnippet> snippets = dbHelper.getSongSnippets(song.getId());
+        for (SongSnippet snippet : snippets) {
+            if (snippet.getIncludeInRankings()) {
+                playbackManager.playSnippet(snippet);
+                return;
+            }
+        }
+
+        if (!playbackManager.isConnected()) {
+            showToast("Connecting to Spotify...");
+            playbackManager.connectSpotify(getApplicationContext(), () -> playbackManager.playSong(song));
+            return;
+        }
+        playbackManager.playSong(song);
+    }
+
+    private void showResults() {
+        setupPhase.setVisibility(View.GONE);
+        matchPhase.setVisibility(View.GONE);
+        resultsPhase.setVisibility(View.VISIBLE);
+
+        leaderboardAdapter.updateEntries(tournament.getLeaderboard());
+    }
+
+    @Override
+    public void onItemClick(int position) {
+        SongModel selectedSong = leaderboardAdapter.getEntries().get(position).song;
+        SelectedSongHolder.getInstance().setSelectedSong(selectedSong);
+        Intent intent = new Intent(this, SongView.class);
+        intent.putExtra("source", "rankings");
+        startActivity(intent);
+        overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
     }
 
     @Override
     public void finish() {
         super.finish();
         overridePendingTransition(R.anim.zoom_in, R.anim.zoom_out);
+    }
+
+    private void showToast(String message) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+        Log.v(TAG, "showed Toast: " + message);
     }
 }

--- a/app/src/main/java/com/ca/tunaro/activites/RankingsActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/RankingsActivity.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class RankingsActivity extends BaseActivity implements Library_RecyclerViewInterface {
     private static final String TAG = "RankingsActivity";
@@ -108,11 +110,20 @@ public class RankingsActivity extends BaseActivity implements Library_RecyclerVi
         findViewById(R.id.preview_button_b).setOnClickListener(v -> previewContender(tournament.getContenderB()));
         findViewById(R.id.restart_button).setOnClickListener(v -> showSetupPhase());
 
-        loadSongPool();
-        showSetupPhase();
+        // Building the pool issues one DB query per annotated song, so load it off the
+        // main thread and render the setup UI once it is ready. Show a loading state
+        // in the meantime rather than a misleading "empty library" message.
+        showLoadingPhase();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+            loadSongPool();
+            runOnUiThread(this::showSetupPhase);
+        });
+        executor.shutdown();
     }
 
-    // The candidate pool is the library: every song with notes or snippets
+    // The candidate pool is the library: every song with notes or snippets.
+    // Runs off the main thread (N+2 synchronous DB reads).
     private void loadSongPool() {
         songPool.clear();
         Set<String> songIds = new LinkedHashSet<>(dbHelper.getSongIdsWithNotes());
@@ -123,6 +134,17 @@ public class RankingsActivity extends BaseActivity implements Library_RecyclerVi
             if (song != null) songPool.add(song);
         }
         Log.d(TAG, "Loaded ranking pool of " + songPool.size() + " songs");
+    }
+
+    private void showLoadingPhase() {
+        setupPhase.setVisibility(View.VISIBLE);
+        matchPhase.setVisibility(View.GONE);
+        resultsPhase.setVisibility(View.GONE);
+
+        poolSummary.setText("Loading your library…");
+        sizeLabel.setVisibility(View.GONE);
+        sizeSpinner.setVisibility(View.GONE);
+        startButton.setVisibility(View.GONE);
     }
 
     private void showSetupPhase() {
@@ -139,6 +161,9 @@ public class RankingsActivity extends BaseActivity implements Library_RecyclerVi
         }
 
         poolSummary.setText(songPool.size() + " songs in your library");
+        sizeLabel.setVisibility(View.VISIBLE);
+        sizeSpinner.setVisibility(View.VISIBLE);
+        startButton.setVisibility(View.VISIBLE);
 
         sizeOptions.clear();
         List<String> labels = new ArrayList<>();

--- a/app/src/main/java/com/ca/tunaro/adapters/RankingsLeaderboardAdapter.java
+++ b/app/src/main/java/com/ca/tunaro/adapters/RankingsLeaderboardAdapter.java
@@ -1,0 +1,88 @@
+package com.ca.tunaro.adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.ca.tunaro.R;
+import com.ca.tunaro.interfaces.Library_RecyclerViewInterface;
+import com.ca.tunaro.utils.RankingsTournament;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RankingsLeaderboardAdapter extends RecyclerView.Adapter<RankingsLeaderboardAdapter.ViewHolder> {
+    private final Context context;
+    private final Library_RecyclerViewInterface recyclerViewInterface;
+    private List<RankingsTournament.LeaderboardEntry> entries = new ArrayList<>();
+
+    public RankingsLeaderboardAdapter(Context context, Library_RecyclerViewInterface recyclerViewInterface) {
+        this.context = context;
+        this.recyclerViewInterface = recyclerViewInterface;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(context).inflate(R.layout.item_leaderboard_entry, parent, false);
+        return new ViewHolder(view, recyclerViewInterface);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        RankingsTournament.LeaderboardEntry entry = entries.get(position);
+        holder.rankText.setText(String.valueOf(entry.rank));
+        holder.songNameText.setText(entry.song.getName());
+        holder.artistText.setText(entry.song.getArtist());
+
+        Glide.with(context)
+                .load(entry.song.getAlbumCoverUrl())
+                .placeholder(R.drawable.playlist_placeholder)
+                .error(R.drawable.playlist_placeholder)
+                .into(holder.albumCoverImage);
+    }
+
+    @Override
+    public int getItemCount() {
+        return entries.size();
+    }
+
+    public void updateEntries(List<RankingsTournament.LeaderboardEntry> newEntries) {
+        this.entries = newEntries;
+        notifyDataSetChanged();
+    }
+
+    public List<RankingsTournament.LeaderboardEntry> getEntries() {
+        return entries;
+    }
+
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+        TextView rankText;
+        ImageView albumCoverImage;
+        TextView songNameText, artistText;
+
+        public ViewHolder(@NonNull View itemView, Library_RecyclerViewInterface recyclerViewInterface) {
+            super(itemView);
+            rankText = itemView.findViewById(R.id.rank_number);
+            albumCoverImage = itemView.findViewById(R.id.album_cover);
+            songNameText = itemView.findViewById(R.id.song_name);
+            artistText = itemView.findViewById(R.id.artist_name);
+
+            itemView.setOnClickListener(v -> {
+                if (recyclerViewInterface != null) {
+                    int pos = getAdapterPosition();
+                    if (pos != RecyclerView.NO_POSITION) {
+                        recyclerViewInterface.onItemClick(pos);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/app/src/main/java/com/ca/tunaro/utils/RankingsTournament.java
+++ b/app/src/main/java/com/ca/tunaro/utils/RankingsTournament.java
@@ -108,7 +108,9 @@ public class RankingsTournament {
     public void reportWinner(SongModel winner) {
         SongModel a = getContenderA();
         SongModel b = getContenderB();
-        SongModel loser = winner == a ? b : a;
+        // Identify the loser by song ID rather than reference identity, so a winner
+        // reconstructed via Parcel/DB reload still matches the correct contender.
+        SongModel loser = winner.getId().equals(a.getId()) ? b : a;
         nextRound.add(winner);
         losersByRound.get(losersByRound.size() - 1).add(loser);
         matchesPlayedInRound++;

--- a/app/src/main/java/com/ca/tunaro/utils/RankingsTournament.java
+++ b/app/src/main/java/com/ca/tunaro/utils/RankingsTournament.java
@@ -1,0 +1,153 @@
+package com.ca.tunaro.utils;
+
+import com.ca.tunaro.models.SongModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Single-elimination tournament bracket over a list of songs.
+ *
+ * The entrant list is padded to the next power of two with byes (null slots),
+ * paired front-to-back so every bye lands opposite a real song. Bye matches
+ * resolve automatically, so callers only ever see matches between two real
+ * songs. Losers are recorded round by round to build the final leaderboard:
+ * champion first, then earlier eliminations grouped by the round they went
+ * out in — songs knocked out in the same round share a rank.
+ */
+public class RankingsTournament {
+
+    public static class LeaderboardEntry {
+        public final int rank;
+        public final SongModel song;
+
+        LeaderboardEntry(int rank, SongModel song) {
+            this.rank = rank;
+            this.song = song;
+        }
+    }
+
+    private List<SongModel> currentRound;   // slot list; match i = slots (2i, 2i+1), bye slots are null
+    private List<SongModel> nextRound;
+    private final List<List<SongModel>> losersByRound = new ArrayList<>();
+    private int matchIndex;
+    private int matchesPlayedInRound;
+    private int totalMatchesInRound;        // real matches only, byes excluded
+    private SongModel champion;
+
+    public RankingsTournament(List<SongModel> entrants) {
+        if (entrants == null || entrants.size() < 2) {
+            throw new IllegalArgumentException("Tournament needs at least 2 songs");
+        }
+
+        int bracketSize = 1;
+        while (bracketSize < entrants.size()) bracketSize *= 2;
+
+        List<SongModel> padded = new ArrayList<>(entrants);
+        while (padded.size() < bracketSize) padded.add(null);
+
+        // Pair slot i against slot (size-1-i). Byes sit at the tail of the
+        // padded list and there are always fewer than half a bracket of them,
+        // so a bye can never meet another bye.
+        currentRound = new ArrayList<>(bracketSize);
+        for (int i = 0; i < bracketSize / 2; i++) {
+            currentRound.add(padded.get(i));
+            currentRound.add(padded.get(bracketSize - 1 - i));
+        }
+
+        beginRound();
+    }
+
+    private void beginRound() {
+        nextRound = new ArrayList<>();
+        matchIndex = 0;
+        matchesPlayedInRound = 0;
+        totalMatchesInRound = 0;
+        losersByRound.add(new ArrayList<>());
+        for (int i = 0; i < currentRound.size(); i += 2) {
+            if (currentRound.get(i) != null && currentRound.get(i + 1) != null) {
+                totalMatchesInRound++;
+            }
+        }
+        skipByes();
+    }
+
+    // Advance past bye matches until a real match (or the end of the round).
+    private void skipByes() {
+        while (matchIndex * 2 < currentRound.size()) {
+            SongModel a = currentRound.get(matchIndex * 2);
+            SongModel b = currentRound.get(matchIndex * 2 + 1);
+            if (a != null && b != null) return;
+            nextRound.add(a != null ? a : b);
+            matchIndex++;
+        }
+        finishRound();
+    }
+
+    private void finishRound() {
+        if (nextRound.size() == 1) {
+            champion = nextRound.get(0);
+            return;
+        }
+        currentRound = nextRound;
+        beginRound();
+    }
+
+    public boolean isFinished() {
+        return champion != null;
+    }
+
+    public SongModel getContenderA() {
+        return currentRound.get(matchIndex * 2);
+    }
+
+    public SongModel getContenderB() {
+        return currentRound.get(matchIndex * 2 + 1);
+    }
+
+    public void reportWinner(SongModel winner) {
+        SongModel a = getContenderA();
+        SongModel b = getContenderB();
+        SongModel loser = winner == a ? b : a;
+        nextRound.add(winner);
+        losersByRound.get(losersByRound.size() - 1).add(loser);
+        matchesPlayedInRound++;
+        matchIndex++;
+        skipByes();
+    }
+
+    public String getRoundName() {
+        int slots = currentRound.size();
+        if (slots == 2) return "Final";
+        if (slots == 4) return "Semi-finals";
+        if (slots == 8) return "Quarter-finals";
+        return "Round of " + slots;
+    }
+
+    public int getMatchNumber() {
+        return matchesPlayedInRound + 1;
+    }
+
+    public int getMatchesInRound() {
+        return totalMatchesInRound;
+    }
+
+    /**
+     * Final standings, only valid once {@link #isFinished()}. The champion is
+     * rank 1; every loser's rank is the position of their elimination round,
+     * so both Semi-final losers share rank 3, Quarter-final losers rank 5, etc.
+     */
+    public List<LeaderboardEntry> getLeaderboard() {
+        List<LeaderboardEntry> leaderboard = new ArrayList<>();
+        leaderboard.add(new LeaderboardEntry(1, champion));
+        int rank = 2;
+        for (int round = losersByRound.size() - 1; round >= 0; round--) {
+            List<SongModel> losers = losersByRound.get(round);
+            for (int i = losers.size() - 1; i >= 0; i--) {
+                leaderboard.add(new LeaderboardEntry(rank, losers.get(i)));
+            }
+            rank += losers.size();
+        }
+        return leaderboard;
+    }
+}

--- a/app/src/main/res/layout/activity_rankings.xml
+++ b/app/src/main/res/layout/activity_rankings.xml
@@ -11,7 +11,7 @@
         android:id="@+id/rankings_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="40dp"
         android:text="Rankings"
         android:textColor="@color/white"
         android:textSize="30sp"
@@ -20,24 +20,296 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/placeholder_text"
-        android:layout_width="wrap_content"
+    <!-- Setup phase: choose the tournament size and start -->
+    <LinearLayout
+        android:id="@+id/setup_phase"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Coming Soon!"
-        android:textColor="@color/white"
-        android:textSize="24sp"
+        android:layout_marginStart="32dp"
+        android:layout_marginEnd="32dp"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/rankings_title"
+        app:layout_constraintVertical_bias="0.35">
 
-    <Button
-        android:id="@+id/back_button"
-        android:layout_width="wrap_content"
+        <TextView
+            android:id="@+id/pool_summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:textColor="@color/white"
+            android:textSize="18sp" />
+
+        <TextView
+            android:id="@+id/size_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="Tournament size"
+            android:textColor="@color/faintTanAccent"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <Spinner
+            android:id="@+id/tournament_size_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="#1AFFFFFF"
+            android:padding="8dp"
+            android:popupBackground="#222222" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/start_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:backgroundTint="@color/tanAccent"
+            android:padding="12dp"
+            android:text="Start Tournament"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:cornerRadius="24dp" />
+
+    </LinearLayout>
+
+    <!-- Match phase: two contenders, tap the preferred song -->
+    <LinearLayout
+        android:id="@+id/match_phase"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="32dp"
-        android:text="Back"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/rankings_title"
+        app:layout_constraintVertical_bias="0.3">
+
+        <TextView
+            android:id="@+id/round_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/tanAccent"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/match_progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/white"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/match_instruction"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Tap the song you prefer"
+            android:textColor="@color/faintTanAccent"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/song_card_a"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:clickable="true"
+                android:focusable="true"
+                app:cardBackgroundColor="#E0E0E0"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="4dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical"
+                    android:padding="12dp">
+
+                    <ImageView
+                        android:id="@+id/cover_a"
+                        android:layout_width="110dp"
+                        android:layout_height="110dp"
+                        android:scaleType="centerCrop" />
+
+                    <TextView
+                        android:id="@+id/song_name_a"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="2"
+                        android:textAlignment="center"
+                        android:textColor="@color/black"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/artist_name_a"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textAlignment="center"
+                        android:textColor="@color/black"
+                        android:textSize="12sp" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/preview_button_a"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:backgroundTint="@color/purpleTheme"
+                        android:text="Preview"
+                        android:textColor="@color/white"
+                        android:textSize="12sp"
+                        app:cornerRadius="18dp" />
+
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+            <TextView
+                android:id="@+id/vs_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="12dp"
+                android:text="VS"
+                android:textColor="@color/white"
+                android:textSize="20sp"
+                android:textStyle="bold" />
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/song_card_b"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:clickable="true"
+                android:focusable="true"
+                app:cardBackgroundColor="#E0E0E0"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="4dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical"
+                    android:padding="12dp">
+
+                    <ImageView
+                        android:id="@+id/cover_b"
+                        android:layout_width="110dp"
+                        android:layout_height="110dp"
+                        android:scaleType="centerCrop" />
+
+                    <TextView
+                        android:id="@+id/song_name_b"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="2"
+                        android:textAlignment="center"
+                        android:textColor="@color/black"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/artist_name_b"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textAlignment="center"
+                        android:textColor="@color/black"
+                        android:textSize="12sp" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/preview_button_b"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:backgroundTint="@color/purpleTheme"
+                        android:text="Preview"
+                        android:textColor="@color/white"
+                        android:textSize="12sp"
+                        app:cornerRadius="18dp" />
+
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <!-- Results phase: the final leaderboard -->
+    <LinearLayout
+        android:id="@+id/results_phase"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/playback_bar"
+        app:layout_constraintTop_toBottomOf="@+id/rankings_title">
+
+        <TextView
+            android:id="@+id/leaderboard_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Your Leaderboard"
+            android:textColor="@color/tanAccent"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/leaderboard_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            android:layout_weight="1"
+            tools:listitem="@layout/item_leaderboard_entry" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/restart_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:backgroundTint="@color/tanAccent"
+            android:padding="12dp"
+            android:text="Play Again"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:cornerRadius="24dp" />
+
+    </LinearLayout>
+
+    <include
+        android:id="@+id/playback_bar"
+        layout="@layout/playback_bar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/playback_bar_height"
+        android:layout_gravity="bottom"
+        android:layout_marginBottom="10dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/item_leaderboard_entry.xml
+++ b/app/src/main/res/layout/item_leaderboard_entry.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/rank_number"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <ImageView
+            android:id="@+id/album_cover"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="8dp"
+            android:scaleType="centerCrop" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/song_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/artist_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/test/java/com/ca/tunaro/utils/RankingsTournamentTest.java
+++ b/app/src/test/java/com/ca/tunaro/utils/RankingsTournamentTest.java
@@ -1,0 +1,106 @@
+package com.ca.tunaro.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.ca.tunaro.models.SongModel;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class RankingsTournamentTest {
+
+    private static List<SongModel> songs(int count) {
+        List<SongModel> list = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(new SongModel("spotify:track:" + i, "Song " + i, "Artist " + i,
+                    180000, "spotify:track:" + i, null, 0, "Album " + i, "2020-01-01"));
+        }
+        return list;
+    }
+
+    // Play every match to completion, always picking contender A, and return
+    // the number of real matches presented.
+    private static int playThrough(RankingsTournament tournament) {
+        int matchesPlayed = 0;
+        while (!tournament.isFinished()) {
+            assertNotNull(tournament.getContenderA());
+            assertNotNull(tournament.getContenderB());
+            tournament.reportWinner(tournament.getContenderA());
+            matchesPlayed++;
+        }
+        return matchesPlayed;
+    }
+
+    @Test
+    public void powerOfTwoBracketPlaysAllMatches() {
+        RankingsTournament tournament = new RankingsTournament(songs(8));
+        assertEquals("Quarter-finals", tournament.getRoundName());
+        assertEquals(4, tournament.getMatchesInRound());
+        assertEquals(7, playThrough(tournament));
+    }
+
+    @Test
+    public void byeBracketPresentsOnlyRealMatches() {
+        // 5 entrants pad to a bracket of 8 with 3 byes: still n-1 real matches
+        RankingsTournament tournament = new RankingsTournament(songs(5));
+        assertEquals(1, tournament.getMatchesInRound());
+        assertEquals(4, playThrough(tournament));
+    }
+
+    @Test
+    public void twoSongsIsASingleFinal() {
+        RankingsTournament tournament = new RankingsTournament(songs(2));
+        assertEquals("Final", tournament.getRoundName());
+        assertEquals(1, playThrough(tournament));
+    }
+
+    @Test
+    public void leaderboardContainsEverySongOnce() {
+        List<SongModel> entrants = songs(6);
+        RankingsTournament tournament = new RankingsTournament(entrants);
+        playThrough(tournament);
+
+        List<RankingsTournament.LeaderboardEntry> leaderboard = tournament.getLeaderboard();
+        assertEquals(entrants.size(), leaderboard.size());
+
+        Set<SongModel> seen = new HashSet<>();
+        for (RankingsTournament.LeaderboardEntry entry : leaderboard) {
+            assertTrue(seen.add(entry.song));
+        }
+    }
+
+    @Test
+    public void leaderboardSharesRanksWithinARound() {
+        RankingsTournament tournament = new RankingsTournament(songs(4));
+
+        // Song 0 beats Song 3, Song 1 beats Song 2, Song 0 wins the final
+        playThrough(tournament);
+
+        List<RankingsTournament.LeaderboardEntry> leaderboard = tournament.getLeaderboard();
+        assertEquals(1, leaderboard.get(0).rank);
+        assertEquals(2, leaderboard.get(1).rank);
+        assertEquals(3, leaderboard.get(2).rank);
+        assertEquals(3, leaderboard.get(3).rank);
+    }
+
+    @Test
+    public void championHeadsTheLeaderboard() {
+        List<SongModel> entrants = songs(8);
+        SongModel favourite = entrants.get(3);
+
+        RankingsTournament tournament = new RankingsTournament(entrants);
+        while (!tournament.isFinished()) {
+            SongModel a = tournament.getContenderA();
+            tournament.reportWinner(a == favourite || tournament.getContenderB() != favourite
+                    ? a : favourite);
+        }
+
+        assertEquals(favourite, tournament.getLeaderboard().get(0).song);
+    }
+}


### PR DESCRIPTION
Closes #2.

Replaces the placeholder `RankingsActivity` with a full tournament-style ranking game.

## What's included
- **`utils/RankingsTournament.java`** — pure-Java bracket logic with bye handling for non-power-of-two fields.
- **`RankingsActivity.java`** — three-phase UI: size selection over the notes/snippets library pool, tap-to-choose matchups with snippet/song previews via `PlaybackManager`, and a final leaderboard with shared per-round ranks.
- **`adapters/RankingsLeaderboardAdapter.java`** + **`item_leaderboard_entry.xml`** — leaderboard row rendering following existing conventions.
- **`RankingsTournamentTest.java`** — the repo's first unit tests, covering the bracket logic.

## Verification
- `compileDebugJavaWithJavac` — clean against current master.
- `testDebugUnitTest` — 6/6 passing.