### PR TITLE
Re-authorize Spotify when the App-Remote grant lapses

### DIFF
--- a/app/src/main/java/com/ca/tunaro/BaseActivity.java
+++ b/app/src/main/java/com/ca/tunaro/BaseActivity.java
@@ -887,7 +887,30 @@ public class BaseActivity extends AppCompatActivity implements PlaybackManager.P
 
     @Override
     public void onConnectionStateChanged(boolean isConnected) {
-        // might want to show some UI feedback when connection state changes
+        // A successful (re)connection clears any in-flight re-auth so a future
+        // lapse can trigger the flow again.
+        if (isConnected) {
+            reauthInProgress = false;
+        }
+    }
+
+    // Guards against every registered Activity (and every connection retry)
+    // launching the re-auth flow at once. Static so it is shared across the
+    // whole Activity stack; cleared once a connection succeeds.
+    private static boolean reauthInProgress = false;
+
+    @Override
+    public void onAuthorizationRequired() {
+        // Spotify's App-Remote grant has lapsed. Route to MainActivity to re-run
+        // the consent flow, which re-establishes the grant. Fire only once.
+        if (reauthInProgress) return;
+        reauthInProgress = true;
+        runOnUiThread(() -> {
+            Intent intent = new Intent(this, MainActivity.class);
+            intent.putExtra(MainActivity.EXTRA_FORCE_REAUTH, true);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(intent);
+        });
     }
 
     public void setDeviceWarningVisible(boolean visible) {

--- a/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
@@ -55,6 +55,10 @@ import se.michaelthelin.spotify.requests.data.users_profile.GetCurrentUsersProfi
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";
 
+    // Set by BaseActivity when Spotify reports the App-Remote grant has lapsed:
+    // forces the consent flow instead of silently restoring the cached session.
+    public static final String EXTRA_FORCE_REAUTH = "force_reauth";
+
     // Minimum time the spinner splash stays visible on the fast (already-logged-in) path.
     private static final long SPLASH_MIN_DISPLAY_MS = 1200;
 
@@ -107,8 +111,13 @@ public class MainActivity extends AppCompatActivity {
                 REDIRECT_URI.toString()
         );
 
+        // When re-auth is forced (App-Remote grant lapsed), skip silent restore and
+        // go straight to the consent flow so Spotify re-issues the grant.
+        boolean forceReauth = getIntent() != null
+                && getIntent().getBooleanExtra(EXTRA_FORCE_REAUTH, false);
+
         // Restore session from saved tokens (silent recovery)
-        if (tryRestoreSession()) {
+        if (!forceReauth && tryRestoreSession()) {
             Log.d(TAG, "Session restored from saved tokens");
             connectSpotifyAppRemote();
 

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -16,6 +16,7 @@ import com.ca.tunaro.utils.SongCache;
 import com.spotify.android.appremote.api.ConnectionParams;
 import com.spotify.android.appremote.api.Connector;
 import com.spotify.android.appremote.api.SpotifyAppRemote;
+import com.spotify.android.appremote.api.error.UserNotAuthorizedException;
 import com.spotify.protocol.types.PlayerState;
 import com.spotify.protocol.types.Track;
 
@@ -119,6 +120,11 @@ public class PlaybackManager {
         void onConnectionStateChanged(boolean isConnected);
 
         void onPlaybackPositionChanged(long positionMs, long durationMs);
+
+        // Called when Spotify reports the App-Remote authorization has lapsed and
+        // the user must re-complete the consent flow. Default no-op so listeners
+        // that don't handle re-auth need no changes.
+        default void onAuthorizationRequired() {}
     }
 
     private PlaybackManager() {
@@ -218,6 +224,18 @@ public class PlaybackManager {
 
                 Log.w(TAG, "Spotify remote connection failed: " + throwable.getMessage(), throwable);
                 notifyConnectionStateChanged();
+
+                // A UserNotAuthorized failure means the App-Remote grant has lapsed
+                // (e.g. expired or the Spotify app was re-logged). Retrying just fails
+                // identically until the user re-completes the consent flow, so skip the
+                // backoff loop and signal the UI to re-authorize instead.
+                if (throwable instanceof UserNotAuthorizedException) {
+                    connectRetryCount = 0;
+                    Log.w(TAG, "Spotify App-Remote authorization required; requesting re-auth");
+                    notifyAuthorizationRequired();
+                    return;
+                }
+
                 scheduleRetryOrGiveUp(onSuccess);
             }
         });
@@ -979,6 +997,12 @@ public class PlaybackManager {
     private void notifyPlaybackPositionChanged() {
         for (PlaybackListener listener : listeners) {
             listener.onPlaybackPositionChanged(currentPositionMs, durationMs);
+        }
+    }
+
+    private void notifyAuthorizationRequired() {
+        for (PlaybackListener listener : listeners) {
+            listener.onAuthorizationRequired();
         }
     }
 


### PR DESCRIPTION
## Problem

When a cached session was restored, `MainActivity` skipped the Spotify authorization consent flow entirely and went straight to `HomeActivity`. The App-Remote grant is separate from the Web-API token, so once it lapses (expiry, or the Spotify app being re-logged), the remote connection fails with `UserNotAuthorizedException` and the retry/backoff loop can never recover it. The app appears logged in — browsing works off the cached bearer token — but anything touching playback can't connect, with no in-app way to re-consent.

## Fix

- **`PlaybackManager`** — detect `UserNotAuthorizedException` in the connection `onFailure`. Since retrying just fails identically until the user re-consents, skip the backoff loop and signal listeners via a new `onAuthorizationRequired()` callback (default no-op, so existing listeners need no changes).
- **`BaseActivity`** — route that signal back through `MainActivity` with `EXTRA_FORCE_REAUTH`, guarded so concurrent listeners/retries launch it only once; the guard clears on a successful reconnect.
- **`MainActivity`** — honour `EXTRA_FORCE_REAUTH` by skipping the silent session restore and running the consent flow, which re-establishes the grant.

Net effect: a lapsed App-Remote grant now self-heals instead of dead-ending in retries.

## Testing

Built and deployed to a physical device. Verified `PlaybackManager: Connected to Spotify remote` on both the fresh-consent path (`Auth response type: code`) and a subsequent restart via the normal session-restore path.