### PR TITLE
Foreground service as playback-session anchor (#116)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ secrets.xml
 STATUS.md
 docs/
 CONTEXT.md
+
+# Local deploy script (build + install to phone over Tailscale)
+deploy.sh

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
 
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.browser:browser:1.8.0")
+    implementation("androidx.media:media:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -83,6 +86,19 @@
             android:name=".activites.DeveloperActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
+
+        <!-- Lifetime anchor for a playback session (ADR-0002). Keeps the process
+             alive so PlaybackManager's playback brain keeps steering Spotify while
+             backgrounded. The MEDIA_BUTTON filter lets MediaSessionCompat route
+             notification/lock-screen/bluetooth transport events back to the service. -->
+        <service
+            android:name=".services.PlaybackService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </service>
 
         <activity
             android:name="com.spotify.sdk.android.auth.LoginActivity"

--- a/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
+++ b/app/src/main/java/com/ca/tunaro/activites/MainActivity.java
@@ -88,6 +88,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main_splash);
         applyRandomSplashGradient();
 
+        requestNotificationPermissionIfNeeded();
+
         // Set the singleton instance
         instance = this;
         Log.d(TAG, "onCreate: MainActivity instance is now " + instance);
@@ -183,6 +185,23 @@ public class MainActivity extends AppCompatActivity {
             {0xFF001B3A, 0xFF4A90E2}, // midnight blue -> sky blue
             {0xFF0B1D51, 0xFF18C6B0}, // royal navy -> aqua
     };
+
+    // On Android 13+ the playback-session media notification (ADR-0002) is hidden
+    // unless POST_NOTIFICATIONS is granted. Request it once at startup; the result
+    // is not awaited — playback still works, only the notification is suppressed if
+    // denied.
+    private void requestNotificationPermissionIfNeeded() {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU) return;
+        if (androidx.core.content.ContextCompat.checkSelfPermission(this,
+                android.Manifest.permission.POST_NOTIFICATIONS)
+                == android.content.pm.PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+        androidx.core.app.ActivityCompat.requestPermissions(this,
+                new String[]{android.Manifest.permission.POST_NOTIFICATIONS}, REQUEST_POST_NOTIFICATIONS);
+    }
+
+    private static final int REQUEST_POST_NOTIFICATIONS = 2001;
 
     private void applyRandomSplashGradient() {
         View root = findViewById(R.id.splash_root);

--- a/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
+++ b/app/src/main/java/com/ca/tunaro/managers/PlaybackManager.java
@@ -1,16 +1,20 @@
 package com.ca.tunaro.managers;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.widget.Toast;
+
+import androidx.core.content.ContextCompat;
 
 import com.ca.tunaro.BaseActivity;
 import com.ca.tunaro.activites.MainActivity;
 import com.ca.tunaro.models.SongModel;
 import com.ca.tunaro.database.DatabaseHelper;
 import com.ca.tunaro.models.SongSnippet;
+import com.ca.tunaro.services.PlaybackService;
 import com.ca.tunaro.utils.DeviceChecker;
 import com.ca.tunaro.utils.SongCache;
 import com.spotify.android.appremote.api.ConnectionParams;
@@ -87,6 +91,21 @@ public class PlaybackManager {
     // Timestamp of last advance — suppress end-of-song check for 3s after an advance
     // to avoid Spotify returning stale position data for the newly-started track.
     private long lastAdvanceTimeMs = 0;
+
+    //#region Playback-session lifetime anchor (ADR-0002)
+    // PlaybackService is a foreground service that keeps the process alive for the
+    // duration of a playback session, so this playback brain keeps running while
+    // backgrounded (the real fix for process death). PlaybackManager owns the
+    // session lifecycle: it starts the service when a track is confirmed playing
+    // and stops it on a genuine session-end. No state moves into the service.
+    private boolean sessionActive = false;
+    // A brief pause keeps the session alive and resumable; a long idle pause is
+    // treated as a session end, since a paused session steers nothing and no longer
+    // justifies pinning the process.
+    private static final long PAUSED_SESSION_TIMEOUT_MS = 30 * 60 * 1000L;
+    private final Handler sessionHandler = new Handler(Looper.getMainLooper());
+    private Runnable pausedTimeoutRunnable;
+    //#endregion
 
     //#region Snippet Playback Fields
     // The behaviour applied when a snippet's end-timer fires. Transient: held in
@@ -316,6 +335,11 @@ public class PlaybackManager {
             boolean wasPlaying = isPlaying;
             isPlaying = !playerState.isPaused;
 
+            // Session choke point (ADR-0002): a confirmed-playing state anchors the
+            // process for the session; a pause keeps the anchor but arms the idle
+            // timeout. This is the single place a session is started.
+            updateSessionForState(isPlaying);
+
             // Notify if state or track changed
             if (wasPlaying != isPlaying || trackChanged) {
                 notifyPlaybackStateChanged();
@@ -351,6 +375,11 @@ public class PlaybackManager {
             if (isTrackingPosition) {
                 stopPositionTracking();
             }
+
+            // A null track is ambiguous (transient transition vs. genuine stop), so
+            // the session is not torn down here; instead arm the idle timeout so a
+            // real stop is eventually reaped without risking a mid-transition kill.
+            updateSessionForState(false);
         }
     }
 
@@ -1039,6 +1068,67 @@ public class PlaybackManager {
         }
     }
 
+    //#region Playback-session lifetime anchor (ADR-0002)
+
+    // Update the session anchor from the current play/pause state. Called from the
+    // single choke point (processPlayerState): a confirmed-playing state starts the
+    // service and clears any pending paused-timeout; a paused/stopped state arms the
+    // timeout so a long idle session is eventually reaped.
+    private void updateSessionForState(boolean playing) {
+        if (playing) {
+            cancelPausedTimeout();
+            startPlaybackSession();
+        } else if (sessionActive) {
+            armPausedTimeout();
+        }
+    }
+
+    private void startPlaybackSession() {
+        if (sessionActive || applicationContext == null) return;
+        sessionActive = true;
+        try {
+            ContextCompat.startForegroundService(applicationContext,
+                    new Intent(applicationContext, PlaybackService.class));
+            Log.d(TAG, "Playback session started (foreground service)");
+        } catch (Exception e) {
+            // Background-start restriction (Android 12+): a session confirmed while
+            // Tunaro is backgrounded (e.g. a Spotify autoplay track change) may be
+            // refused. No recovery — the brain keeps running until the process is
+            // reclaimed; the session simply has no anchor this time.
+            sessionActive = false;
+            Log.w(TAG, "Could not start playback session: " + e.getMessage());
+        }
+    }
+
+    private void stopPlaybackSession() {
+        cancelPausedTimeout();
+        if (!sessionActive) return;
+        sessionActive = false;
+        if (applicationContext != null) {
+            applicationContext.stopService(new Intent(applicationContext, PlaybackService.class));
+            Log.d(TAG, "Playback session stopped");
+        }
+    }
+
+    private void armPausedTimeout() {
+        if (pausedTimeoutRunnable != null) return; // already counting down
+        pausedTimeoutRunnable = () -> {
+            pausedTimeoutRunnable = null;
+            Log.d(TAG, "Session paused for " + PAUSED_SESSION_TIMEOUT_MS + "ms — ending session");
+            stopPlaybackSession();
+        };
+        sessionHandler.postDelayed(pausedTimeoutRunnable, PAUSED_SESSION_TIMEOUT_MS);
+    }
+
+    private void cancelPausedTimeout() {
+        if (pausedTimeoutRunnable != null) {
+            sessionHandler.removeCallbacks(pausedTimeoutRunnable);
+            pausedTimeoutRunnable = null;
+        }
+    }
+
+    //#endregion
+
     //#region Getters
 
     public boolean isPlaying() {
@@ -1104,6 +1194,7 @@ public class PlaybackManager {
     }
 
     public void disconnect() {
+        stopPlaybackSession();
         stopPositionTracking();
         stopListenTracking();
         cancelCurrentSnippetTimer();

--- a/app/src/main/java/com/ca/tunaro/services/PlaybackService.java
+++ b/app/src/main/java/com/ca/tunaro/services/PlaybackService.java
@@ -9,7 +9,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
@@ -57,6 +59,15 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
     private Bitmap currentArt;
     private String currentArtSongId;
 
+    // Media-carousel precedence tracking (see assertPrecedence()).
+    private boolean lastPlaying = false;
+    private String lastNudgeSongId;
+
+    // Spotify emits its own session update just after playback starts, so a single
+    // immediate reassert can be out-recencied; reassert again at these delays.
+    private final Handler nudgeHandler = new Handler(Looper.getMainLooper());
+    private static final long[] NUDGE_DELAYS_MS = { 350L, 1200L, 3000L };
+
     @Nullable
     @Override
     public IBinder onBind(Intent intent) {
@@ -93,6 +104,7 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
 
     @Override
     public void onDestroy() {
+        nudgeHandler.removeCallbacksAndMessages(null);
         if (playbackManager != null) {
             playbackManager.removeListener(this);
         }
@@ -109,6 +121,21 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
 
     @Override
     public void onPlaybackStateChanged(boolean isPlaying, SongModel currentSong) {
+        // On a transition into playing or a track change, assert media-carousel
+        // precedence (best-effort — the system owns final ordering).
+        String songId = currentSong != null ? currentSong.getId() : null;
+        boolean becamePlaying = isPlaying && !lastPlaying;
+        boolean trackChanged = songId != null && !songId.equals(lastNudgeSongId);
+        if (isPlaying && (becamePlaying || trackChanged)) {
+            assertPrecedence();
+            schedulePrecedenceReasserts();
+        } else if (!isPlaying) {
+            // Paused: stop reasserting so it can't steal the card back post-pause.
+            nudgeHandler.removeCallbacksAndMessages(null);
+        }
+        lastPlaying = isPlaying;
+        lastNudgeSongId = songId;
+
         updateMetadata(currentSong);
         updatePlaybackState();
         postNotification();
@@ -125,6 +152,33 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
     public void onConnectionStateChanged(boolean isConnected) {
         // Connection changes don't affect the notification; session lifecycle on
         // disconnect is handled by PlaybackManager stopping the service.
+    }
+
+    //#endregion
+
+    //#region Media-carousel precedence
+
+    // Assert precedence over Spotify on two independent signals the system uses to
+    // rank the media carousel:
+    //   1. Session recency — push a brief PAUSED→PLAYING edge. The stack ranks by
+    //      the session that most recently transitioned to playing, not by
+    //      setActive() or by re-setting the same STATE_PLAYING (which the poller
+    //      already does), so a real edge is what re-recencies this session.
+    //   2. Notification recency — re-post with an advancing when-time, since
+    //      SystemUI's carousel ranks the media notifications, not the session stack.
+    private void assertPrecedence() {
+        if (mediaSession == null || playbackManager == null || !playbackManager.isPlaying()) return;
+        mediaSession.setActive(true);
+        mediaSession.setPlaybackState(buildState(false));
+        mediaSession.setPlaybackState(buildState(true));
+        postNotification();
+    }
+
+    private void schedulePrecedenceReasserts() {
+        nudgeHandler.removeCallbacksAndMessages(null);
+        for (long delay : NUDGE_DELAYS_MS) {
+            nudgeHandler.postDelayed(this::assertPrecedence, delay);
+        }
     }
 
     //#endregion
@@ -156,15 +210,9 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
             if (playbackManager != null) playbackManager.previous();
         }
 
-        @Override
-        public void onSeekTo(long pos) {
-            // Gated in the PlaybackState actions: ACTION_SEEK_TO is only advertised
-            // outside snippet mode, so the notification seekbar is non-draggable
-            // while a snippet owns the playhead. Guard here too for safety.
-            if (playbackManager != null && !playbackManager.isSnippetMode()) {
-                playbackManager.seekTo(pos);
-            }
-        }
+        // Seeking is intentionally not handled: ACTION_SEEK_TO is not advertised,
+        // so the notification progress bar is display-only. Routing a seek through
+        // Spotify would hand media-carousel precedence back to it.
     };
 
     //#endregion
@@ -188,25 +236,25 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
 
     private void updatePlaybackState() {
         if (mediaSession == null || playbackManager == null) return;
-        boolean isPlaying = playbackManager.isPlaying();
+        mediaSession.setPlaybackState(buildState(playbackManager.isPlaying()));
+    }
+
+    private PlaybackStateCompat buildState(boolean playing) {
         long actions = PlaybackStateCompat.ACTION_PLAY
                 | PlaybackStateCompat.ACTION_PAUSE
                 | PlaybackStateCompat.ACTION_PLAY_PAUSE
                 | PlaybackStateCompat.ACTION_SKIP_TO_NEXT
                 | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS;
-        // Draggable seekbar in normal playback; suppressed during snippet mode,
-        // mirroring the in-app rule (CONTEXT.md, Tunaro media session).
-        if (!playbackManager.isSnippetMode()) {
-            actions |= PlaybackStateCompat.ACTION_SEEK_TO;
-        }
-        PlaybackStateCompat state = new PlaybackStateCompat.Builder()
+        // ACTION_SEEK_TO is deliberately omitted so the notification progress bar
+        // is display-only (non-draggable): a notification seek routes through
+        // Spotify and hands media-carousel precedence back to it.
+        return new PlaybackStateCompat.Builder()
                 .setActions(actions)
                 .setState(
-                        isPlaying ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED,
+                        playing ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED,
                         playbackManager.getCurrentPositionMs(),
-                        isPlaying ? 1f : 0f)
+                        playing ? 1f : 0f)
                 .build();
-        mediaSession.setPlaybackState(state);
     }
 
     private void postNotification() {
@@ -226,6 +274,11 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
                         .setVisibility(androidx.core.app.NotificationCompat.VISIBILITY_PUBLIC)
                         .setOngoing(true)
                         .setContentIntent(buildContentIntent())
+                        // Advancing when-time (hidden) feeds SystemUI's media-carousel
+                        // recency ranking, so a reassert re-post reads as the most
+                        // recently active media notification. See assertPrecedence().
+                        .setWhen(System.currentTimeMillis())
+                        .setShowWhen(false)
                         .setOnlyAlertOnce(true);
 
         if (currentArt != null && song != null && song.getId().equals(currentArtSongId)) {

--- a/app/src/main/java/com/ca/tunaro/services/PlaybackService.java
+++ b/app/src/main/java/com/ca/tunaro/services/PlaybackService.java
@@ -243,8 +243,13 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
         long actions = PlaybackStateCompat.ACTION_PLAY
                 | PlaybackStateCompat.ACTION_PAUSE
                 | PlaybackStateCompat.ACTION_PLAY_PAUSE
-                | PlaybackStateCompat.ACTION_SKIP_TO_NEXT
                 | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS;
+        // Only advertise skip-to-next when a next track actually exists. In Stop
+        // mode at the end of the queue hasNext() is false, so the next control is
+        // dropped rather than presented as a dead button.
+        if (playbackManager.hasNext()) {
+            actions |= PlaybackStateCompat.ACTION_SKIP_TO_NEXT;
+        }
         // ACTION_SEEK_TO is deliberately omitted so the notification progress bar
         // is display-only (non-draggable): a notification seek routes through
         // Spotify and hands media-carousel precedence back to it.
@@ -291,12 +296,18 @@ public class PlaybackService extends Service implements PlaybackManager.Playback
                 isPlaying ? R.drawable.ic_notif_pause : R.drawable.ic_notif_play,
                 getString(isPlaying ? R.string.notif_pause : R.string.notif_play),
                 MediaButtonReceiver.buildMediaButtonPendingIntent(this, PlaybackStateCompat.ACTION_PLAY_PAUSE));
-        builder.addAction(R.drawable.ic_notif_skip_next, getString(R.string.notif_next),
-                MediaButtonReceiver.buildMediaButtonPendingIntent(this, PlaybackStateCompat.ACTION_SKIP_TO_NEXT));
 
-        builder.setStyle(new MediaStyle()
-                .setMediaSession(mediaSession.getSessionToken())
-                .setShowActionsInCompactView(0, 1, 2));
+        // Omit the next control entirely when there is no next track (Stop mode at
+        // the end of the queue), so compact view shows prev + play/pause only.
+        boolean showNext = playbackManager != null && playbackManager.hasNext();
+        if (showNext) {
+            builder.addAction(R.drawable.ic_notif_skip_next, getString(R.string.notif_next),
+                    MediaButtonReceiver.buildMediaButtonPendingIntent(this, PlaybackStateCompat.ACTION_SKIP_TO_NEXT));
+        }
+
+        MediaStyle style = new MediaStyle().setMediaSession(mediaSession.getSessionToken());
+        style.setShowActionsInCompactView(showNext ? new int[]{0, 1, 2} : new int[]{0, 1});
+        builder.setStyle(style);
 
         return builder.build();
     }

--- a/app/src/main/java/com/ca/tunaro/services/PlaybackService.java
+++ b/app/src/main/java/com/ca/tunaro/services/PlaybackService.java
@@ -1,0 +1,311 @@
+package com.ca.tunaro.services;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.os.Build;
+import android.os.IBinder;
+import android.support.v4.media.MediaMetadataCompat;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.media.app.NotificationCompat.MediaStyle;
+import androidx.media.session.MediaButtonReceiver;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.target.CustomTarget;
+import com.bumptech.glide.request.transition.Transition;
+import com.ca.tunaro.R;
+import com.ca.tunaro.managers.PlaybackManager;
+import com.ca.tunaro.models.SongModel;
+
+/**
+ * Foreground service acting purely as a lifetime anchor for a playback session
+ * (ADR-0002). It holds no queue/snippet/poller state and runs none of that
+ * logic: its jobs are to keep the process alive so PlaybackManager's playback
+ * brain keeps steering Spotify while backgrounded, and to present a MediaStyle
+ * media notification whose transport controls route back into PlaybackManager's
+ * custom queue.
+ *
+ * <p>PlaybackManager owns the session lifecycle and starts/stops this service;
+ * see {@code PlaybackManager.startPlaybackSession()} / {@code stopPlaybackSession()}.
+ */
+public class PlaybackService extends Service implements PlaybackManager.PlaybackListener {
+    private static final String TAG = "PlaybackService";
+
+    private static final String CHANNEL_ID = "tunaro_playback";
+    private static final int NOTIFICATION_ID = 1001;
+
+    private PlaybackManager playbackManager;
+    private MediaSessionCompat mediaSession;
+    private NotificationManagerCompat notificationManager;
+
+    // The first notification is posted by startForeground in onStartCommand; until
+    // then, listener callbacks update the session silently without posting.
+    private boolean isForegroundStarted = false;
+
+    // Cached album art and the song it belongs to, so metadata/notification can be
+    // rebuilt synchronously while a fresh load runs asynchronously (re-posted on ready).
+    private Bitmap currentArt;
+    private String currentArtSongId;
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null; // Not a bound service — pure anchor, no binder (ADR-0002).
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        playbackManager = PlaybackManager.getInstance();
+        notificationManager = NotificationManagerCompat.from(this);
+        createNotificationChannel();
+
+        mediaSession = new MediaSessionCompat(this, TAG);
+        mediaSession.setCallback(mediaSessionCallback);
+        mediaSession.setActive(true);
+
+        // Register for state/position updates. addListener immediately calls back
+        // with current state, priming the session before startForeground posts.
+        playbackManager.addListener(this);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        isForegroundStarted = true;
+        startForeground(NOTIFICATION_ID, buildNotification());
+        // Route media-button / lock-screen / bluetooth transport events into the
+        // session callback below.
+        MediaButtonReceiver.handleIntent(mediaSession, intent);
+        // No recovery: a session killed under memory pressure ends and is not
+        // resurrected (the queue is deliberately in-memory). See ADR-0002.
+        return START_NOT_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (playbackManager != null) {
+            playbackManager.removeListener(this);
+        }
+        if (mediaSession != null) {
+            mediaSession.setActive(false);
+            mediaSession.release();
+            mediaSession = null;
+        }
+        isForegroundStarted = false;
+        super.onDestroy();
+    }
+
+    //#region PlaybackListener
+
+    @Override
+    public void onPlaybackStateChanged(boolean isPlaying, SongModel currentSong) {
+        updateMetadata(currentSong);
+        updatePlaybackState();
+        postNotification();
+    }
+
+    @Override
+    public void onPlaybackPositionChanged(long positionMs, long durationMs) {
+        // Position-only update: refresh the session state (cheap; the system
+        // seekbar reads position from it) without re-posting the notification.
+        updatePlaybackState();
+    }
+
+    @Override
+    public void onConnectionStateChanged(boolean isConnected) {
+        // Connection changes don't affect the notification; session lifecycle on
+        // disconnect is handled by PlaybackManager stopping the service.
+    }
+
+    //#endregion
+
+    //#region MediaSession → PlaybackManager routing
+
+    private final MediaSessionCompat.Callback mediaSessionCallback = new MediaSessionCompat.Callback() {
+        @Override
+        public void onPlay() {
+            if (playbackManager != null && !playbackManager.isPlaying()) {
+                playbackManager.togglePlayPause();
+            }
+        }
+
+        @Override
+        public void onPause() {
+            if (playbackManager != null && playbackManager.isPlaying()) {
+                playbackManager.togglePlayPause();
+            }
+        }
+
+        @Override
+        public void onSkipToNext() {
+            if (playbackManager != null) playbackManager.next();
+        }
+
+        @Override
+        public void onSkipToPrevious() {
+            if (playbackManager != null) playbackManager.previous();
+        }
+
+        @Override
+        public void onSeekTo(long pos) {
+            // Gated in the PlaybackState actions: ACTION_SEEK_TO is only advertised
+            // outside snippet mode, so the notification seekbar is non-draggable
+            // while a snippet owns the playhead. Guard here too for safety.
+            if (playbackManager != null && !playbackManager.isSnippetMode()) {
+                playbackManager.seekTo(pos);
+            }
+        }
+    };
+
+    //#endregion
+
+    //#region MediaSession + notification building
+
+    private void updateMetadata(SongModel song) {
+        if (mediaSession == null) return;
+        MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder();
+        if (song != null) {
+            builder.putString(MediaMetadataCompat.METADATA_KEY_TITLE, song.getName());
+            builder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, song.getArtist());
+            builder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, playbackManager.getDurationMs());
+            loadArtIfNeeded(song);
+            if (currentArt != null && song.getId().equals(currentArtSongId)) {
+                builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, currentArt);
+            }
+        }
+        mediaSession.setMetadata(builder.build());
+    }
+
+    private void updatePlaybackState() {
+        if (mediaSession == null || playbackManager == null) return;
+        boolean isPlaying = playbackManager.isPlaying();
+        long actions = PlaybackStateCompat.ACTION_PLAY
+                | PlaybackStateCompat.ACTION_PAUSE
+                | PlaybackStateCompat.ACTION_PLAY_PAUSE
+                | PlaybackStateCompat.ACTION_SKIP_TO_NEXT
+                | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS;
+        // Draggable seekbar in normal playback; suppressed during snippet mode,
+        // mirroring the in-app rule (CONTEXT.md, Tunaro media session).
+        if (!playbackManager.isSnippetMode()) {
+            actions |= PlaybackStateCompat.ACTION_SEEK_TO;
+        }
+        PlaybackStateCompat state = new PlaybackStateCompat.Builder()
+                .setActions(actions)
+                .setState(
+                        isPlaying ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED,
+                        playbackManager.getCurrentPositionMs(),
+                        isPlaying ? 1f : 0f)
+                .build();
+        mediaSession.setPlaybackState(state);
+    }
+
+    private void postNotification() {
+        if (!isForegroundStarted || notificationManager == null) return;
+        notificationManager.notify(NOTIFICATION_ID, buildNotification());
+    }
+
+    private Notification buildNotification() {
+        boolean isPlaying = playbackManager != null && playbackManager.isPlaying();
+        SongModel song = playbackManager != null ? playbackManager.getCurrentSong() : null;
+
+        androidx.core.app.NotificationCompat.Builder builder =
+                new androidx.core.app.NotificationCompat.Builder(this, CHANNEL_ID)
+                        .setSmallIcon(R.drawable.ic_notification)
+                        .setContentTitle(song != null ? song.getName() : getString(R.string.app_name))
+                        .setContentText(song != null ? song.getArtist() : null)
+                        .setVisibility(androidx.core.app.NotificationCompat.VISIBILITY_PUBLIC)
+                        .setOngoing(true)
+                        .setContentIntent(buildContentIntent())
+                        .setOnlyAlertOnce(true);
+
+        if (currentArt != null && song != null && song.getId().equals(currentArtSongId)) {
+            builder.setLargeIcon(currentArt);
+        }
+
+        builder.addAction(R.drawable.ic_notif_skip_previous, getString(R.string.notif_previous),
+                MediaButtonReceiver.buildMediaButtonPendingIntent(this, PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS));
+        builder.addAction(
+                isPlaying ? R.drawable.ic_notif_pause : R.drawable.ic_notif_play,
+                getString(isPlaying ? R.string.notif_pause : R.string.notif_play),
+                MediaButtonReceiver.buildMediaButtonPendingIntent(this, PlaybackStateCompat.ACTION_PLAY_PAUSE));
+        builder.addAction(R.drawable.ic_notif_skip_next, getString(R.string.notif_next),
+                MediaButtonReceiver.buildMediaButtonPendingIntent(this, PlaybackStateCompat.ACTION_SKIP_TO_NEXT));
+
+        builder.setStyle(new MediaStyle()
+                .setMediaSession(mediaSession.getSessionToken())
+                .setShowActionsInCompactView(0, 1, 2));
+
+        return builder.build();
+    }
+
+    private PendingIntent buildContentIntent() {
+        Intent launch = getPackageManager().getLaunchIntentForPackage(getPackageName());
+        if (launch == null) {
+            launch = new Intent();
+        }
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            flags |= PendingIntent.FLAG_IMMUTABLE;
+        }
+        return PendingIntent.getActivity(this, 0, launch, flags);
+    }
+
+    // Load album art for the current song asynchronously, then cache it and
+    // re-post so the notification and lock screen pick up the artwork.
+    private void loadArtIfNeeded(SongModel song) {
+        if (song == null || song.getId().equals(currentArtSongId)) {
+            return; // already loaded (or loading) for this song
+        }
+        currentArtSongId = song.getId();
+        currentArt = null;
+        String url = song.getAlbumCoverUrl();
+        if (url == null || url.isEmpty()) return;
+        final String requestedId = song.getId();
+        Glide.with(getApplicationContext())
+                .asBitmap()
+                .load(url)
+                .into(new CustomTarget<Bitmap>() {
+                    @Override
+                    public void onResourceReady(Bitmap resource, @Nullable Transition<? super Bitmap> transition) {
+                        // Ignore a stale load whose song is no longer current.
+                        if (!requestedId.equals(currentArtSongId)) return;
+                        currentArt = resource;
+                        SongModel current = playbackManager != null ? playbackManager.getCurrentSong() : null;
+                        if (current != null) {
+                            updateMetadata(current);
+                        }
+                        postNotification();
+                    }
+
+                    @Override
+                    public void onLoadCleared(@Nullable android.graphics.drawable.Drawable placeholder) {
+                        // No-op: the cached bitmap is dropped when the next song loads.
+                    }
+                });
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID,
+                    getString(R.string.playback_channel_name),
+                    NotificationManager.IMPORTANCE_LOW);
+            channel.setDescription(getString(R.string.playback_channel_description));
+            channel.setShowBadge(false);
+            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            if (manager != null) manager.createNotificationChannel(channel);
+        }
+    }
+
+    //#endregion
+}

--- a/app/src/main/res/drawable/ic_notif_pause.xml
+++ b/app/src/main/res/drawable/ic_notif_pause.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6,19h4L10,5L6,5v14zM14,5v14h4L18,5h-4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notif_play.xml
+++ b/app/src/main/res/drawable/ic_notif_play.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8,5v14l11,-7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notif_skip_next.xml
+++ b/app/src/main/res/drawable/ic_notif_skip_next.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2L18,6h-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notif_skip_previous.xml
+++ b/app/src/main/res/drawable/ic_notif_skip_previous.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z" />
+</vector>

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55 -2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4L14,7h4L18,3h-6z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,12 @@
     <string name="no_playlists_found">No playlists found</string>
     <string name="save">Save</string>
     <string name="app_name" translatable="false">Tunaro</string>
+    <string name="playback_channel_name">Playback</string>
+    <string name="playback_channel_description">Media controls while Tunaro is steering playback</string>
+    <string name="notif_previous">Previous</string>
+    <string name="notif_play">Play</string>
+    <string name="notif_pause">Pause</string>
+    <string name="notif_next">Next</string>
     <string name="title_home">Home</string>
     <string name="title_dashboard">Dashboard</string>
     <string name="title_notifications">Notifications</string>


### PR DESCRIPTION
Adds a foreground service (`PlaybackService`) as a pure lifetime anchor for a playback session, so PlaybackManager's playback brain (queue/snippet/poller) keeps steering Spotify while the app is backgrounded. Closes #116.

Per ADR-0002, no state moves into the service and there is no binder — PlaybackManager stays the unchanged singleton source of truth. The service is a `mediaPlayback` FGS (START_NOT_STICKY) that owns a Tunaro `MediaSessionCompat` powering a MediaStyle notification (album art, live seekbar, prev / play-pause / next, lock-screen controls) whose transport routes back into PlaybackManager's custom queue.

## What's here
- **PlaybackService** — the FGS lifetime anchor + MediaSession + MediaStyle notification, routing transport into PlaybackManager.
- **Session lifecycle driven by PlaybackManager** — starts the service on playback, ends it only on `disconnect()` or a 30-minute-paused timeout (Stop-mode boundary pauses are ordinary pauses; a null track is never torn down directly).
- **POST_NOTIFICATIONS requested at MainActivity startup.**
- **Media-carousel precedence** — best-effort assertion over Spotify's card on play / track-change, pushing both ranking signals (a genuine PAUSED→PLAYING session edge and a notification re-post with advancing when-time), repeated on a short delayed schedule and stopped on pause. Wins the session stack reliably; a fresh Spotify context-play can still momentarily hold SystemUI's card (a single pause/play reclaims it) — the limit of a mirror session.
- **Contextual next control** — the notification's next button and `ACTION_SKIP_TO_NEXT` are dropped when there is no next track (Stop mode at the end of the queue), rather than showing a dead control.
- Notification icons + strings, and the `androidx.media:media` dependency.

Notification-seeking is intentionally display-only: a notification seek routes through Spotify and hands carousel precedence back to it.

Follow-up: #120 (resume-in-place instead of re-running the splash on notification/launcher tap).

## Testing
Verified on device (Galaxy S21 Ultra): no crashes, FGS type `mediaPlayback`, MediaSession live-tracks Spotify position while backgrounded (proving the poller/brain runs), queue advances backgrounded, precedence holds on pause/play/next, and the next button correctly disappears at the end of a Stop-mode queue.